### PR TITLE
[#17] 인증 구현에 한 부분인 jwtTokenProvider 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,14 +29,19 @@ dependencies {
 	// Swagger
 	implementation ('io.springfox:springfox-boot-starter:3.0.0')
 
+	// jwt
+	implementation('io.jsonwebtoken:jjwt-api:0.11.5')
+	implementation('io.jsonwebtoken:jjwt-impl:0.11.5')
+	implementation('io.jsonwebtoken:jjwt-jackson:0.11.5')
+
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 
+	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/project/Tamago/config/CorsConfig.java
+++ b/backend/src/main/java/com/project/Tamago/config/CorsConfig.java
@@ -1,0 +1,24 @@
+package com.project.Tamago.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:9000"));
+        configuration.addAllowedHeader("*");
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH"));
+        configuration.setAllowCredentials(true);
+
+        source.registerCorsConfiguration("/**", configuration);
+        return new CorsFilter(source);
+    }
+}

--- a/backend/src/main/java/com/project/Tamago/config/CorsConfig.java
+++ b/backend/src/main/java/com/project/Tamago/config/CorsConfig.java
@@ -1,24 +1,24 @@
 package com.project.Tamago.config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
-import java.util.List;
-
 @Configuration
 public class CorsConfig {
-    public CorsFilter corsFilter() {
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        CorsConfiguration configuration = new CorsConfiguration();
+	public CorsFilter corsFilter() {
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:9000"));
-        configuration.addAllowedHeader("*");
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH"));
-        configuration.setAllowCredentials(true);
+		configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:9000"));
+		configuration.addAllowedHeader("*");
+		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH"));
+		configuration.setAllowCredentials(true);
 
-        source.registerCorsConfiguration("/**", configuration);
-        return new CorsFilter(source);
-    }
+		source.registerCorsConfiguration("/**", configuration);
+		return new CorsFilter(source);
+	}
 }

--- a/backend/src/main/java/com/project/Tamago/config/SecurityConfig.java
+++ b/backend/src/main/java/com/project/Tamago/config/SecurityConfig.java
@@ -13,6 +13,8 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 public class SecurityConfig {
 
+    private final CorsConfig corsConfig;
+
     @Bean
     public SecurityFilterChain apiFilterChain(HttpSecurity http) throws Exception {
 
@@ -22,6 +24,8 @@ public class SecurityConfig {
                 .httpBasic().disable();
         http
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+        http
+                .addFilter(corsConfig.corsFilter());
         http
                 .authorizeRequests()
                 // swagger

--- a/backend/src/main/java/com/project/Tamago/config/SecurityConfig.java
+++ b/backend/src/main/java/com/project/Tamago/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.project.Tamago.config;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -8,38 +7,40 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
+import lombok.RequiredArgsConstructor;
+
 @Configuration
 @RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig {
 
-    private final CorsConfig corsConfig;
+	private final CorsConfig corsConfig;
 
-    @Bean
-    public SecurityFilterChain apiFilterChain(HttpSecurity http) throws Exception {
+	@Bean
+	public SecurityFilterChain apiFilterChain(HttpSecurity http) throws Exception {
 
-        http
-                .csrf().disable()
-                .formLogin().disable()
-                .httpBasic().disable();
-        http
-                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
-        http
-                .addFilter(corsConfig.corsFilter());
-        http
-                .authorizeRequests()
-                // swagger
-                .antMatchers("/auth/**").permitAll()
-                .antMatchers("/swagger-ui/**").permitAll()
-                .antMatchers("/swagger-ui.html").permitAll()
-                .antMatchers("/swagger/**").permitAll()
-                .antMatchers("/swagger-resources/**").permitAll()
-                .antMatchers("/v2/api-docs").permitAll()
-                .antMatchers("/health").permitAll()
-                .and()
-                .authorizeRequests()
-                .anyRequest().permitAll();
+		http
+			.csrf().disable()
+			.formLogin().disable()
+			.httpBasic().disable();
+		http
+			.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+		http
+			.addFilter(corsConfig.corsFilter());
+		http
+			.authorizeRequests()
+			// swagger
+			.antMatchers("/auth/**").permitAll()
+			.antMatchers("/swagger-ui/**").permitAll()
+			.antMatchers("/swagger-ui.html").permitAll()
+			.antMatchers("/swagger/**").permitAll()
+			.antMatchers("/swagger-resources/**").permitAll()
+			.antMatchers("/v2/api-docs").permitAll()
+			.antMatchers("/health").permitAll()
+			.and()
+			.authorizeRequests()
+			.anyRequest().permitAll();
 
-        return http.build();
-    }
+		return http.build();
+	}
 }

--- a/backend/src/main/java/com/project/Tamago/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/project/Tamago/config/SwaggerConfig.java
@@ -1,9 +1,15 @@
 package com.project.Tamago.config;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
@@ -15,63 +21,61 @@ import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 
-import java.util.*;
-
 @Configuration
 @EnableWebMvc
 public class SwaggerConfig {
-    @Value("${swagger.host}")
-    private String hostUrl;
+	@Value("${swagger.host}")
+	private String hostUrl;
 
-    private ApiInfo swaggerInfo() {
-        return new ApiInfoBuilder().title("Tamago API")
-                .description("Tamago API Docs").build();
-    }
+	private ApiInfo swaggerInfo() {
+		return new ApiInfoBuilder().title("Tamago API")
+			.description("Tamago API Docs").build();
+	}
 
-    @Bean
-    public Docket swaggerApi() {
-        return new Docket(DocumentationType.SWAGGER_2)
-                .host(hostUrl)
-                .consumes(getConsumeContentTypes())
-                .produces(getProduceContentTypes())
-                .apiInfo(swaggerInfo())
-                .securityContexts(Collections.singletonList(securityContext()))
-                .securitySchemes(List.of(apiKey()))
-                .select()
-                .apis(RequestHandlerSelectors.basePackage("com.project.Tamago"))
-                .paths(PathSelectors.any())
-                .build()
-                .useDefaultResponseMessages(false);
-    }
+	@Bean
+	public Docket swaggerApi() {
+		return new Docket(DocumentationType.SWAGGER_2)
+			.host(hostUrl)
+			.consumes(getConsumeContentTypes())
+			.produces(getProduceContentTypes())
+			.apiInfo(swaggerInfo())
+			.securityContexts(Collections.singletonList(securityContext()))
+			.securitySchemes(List.of(apiKey()))
+			.select()
+			.apis(RequestHandlerSelectors.basePackage("com.project.Tamago"))
+			.paths(PathSelectors.any())
+			.build()
+			.useDefaultResponseMessages(false);
+	}
 
-    private ApiKey apiKey() {
-        return new ApiKey("JWT", "Authorization", "header");
-    }
+	private ApiKey apiKey() {
+		return new ApiKey("JWT", "Authorization", "header");
+	}
 
-    private SecurityContext securityContext() {
-        return SecurityContext.builder()
-                .securityReferences(defaultAuth())
-                .build();
-    }
+	private SecurityContext securityContext() {
+		return SecurityContext.builder()
+			.securityReferences(defaultAuth())
+			.build();
+	}
 
-    List<SecurityReference> defaultAuth() {
-        AuthorizationScope authorizationScope
-                = new AuthorizationScope("global", "accessEverything");
-        AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
-        authorizationScopes[0] = authorizationScope;
-        return List.of(new SecurityReference("JWT", authorizationScopes));
-    }
+	List<SecurityReference> defaultAuth() {
+		AuthorizationScope authorizationScope
+			= new AuthorizationScope("global", "accessEverything");
+		AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+		authorizationScopes[0] = authorizationScope;
+		return List.of(new SecurityReference("JWT", authorizationScopes));
+	}
 
-    private Set<String> getConsumeContentTypes() {
-        Set<String> consumes = new HashSet<>();
-        consumes.add("application/json;charset=UTF-8");
-        consumes.add("application/x-www-form-urlencoded");
-        return consumes;
-    }
+	private Set<String> getConsumeContentTypes() {
+		Set<String> consumes = new HashSet<>();
+		consumes.add("application/json;charset=UTF-8");
+		consumes.add("application/x-www-form-urlencoded");
+		return consumes;
+	}
 
-    private Set<String> getProduceContentTypes() {
-        Set<String> produces = new HashSet<>();
-        produces.add("application/json;charset=UTF-8");
-        return produces;
-    }
+	private Set<String> getProduceContentTypes() {
+		Set<String> produces = new HashSet<>();
+		produces.add("application/json;charset=UTF-8");
+		return produces;
+	}
 }

--- a/backend/src/main/java/com/project/Tamago/controller/TestController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TestController.java
@@ -6,6 +6,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.project.Tamago.exception.CustomException;
 
+import static com.project.Tamago.exception.exceptionHandler.ErrorCode.INVALID_INPUT_VALUE;
+
 @RestController
 public class TestController {
 
@@ -15,7 +17,7 @@ public class TestController {
 		if(str.contains("Illegal")){
 			throw new IllegalArgumentException();
 		} else if (str.contains("user")) {
-			throw new CustomException("잘못된 접근입니다.");
+			throw new CustomException(INVALID_INPUT_VALUE);
 		} else if (str.contains("error")) {
 			throw new RuntimeException();
 		}

--- a/backend/src/main/java/com/project/Tamago/controller/TestController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TestController.java
@@ -1,12 +1,12 @@
 package com.project.Tamago.controller;
 
+import static com.project.Tamago.exception.exceptionHandler.ErrorCode.*;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.project.Tamago.exception.CustomException;
-
-import static com.project.Tamago.exception.exceptionHandler.ErrorCode.INVALID_INPUT_VALUE;
 
 @RestController
 public class TestController {
@@ -14,7 +14,7 @@ public class TestController {
 	@GetMapping("/test")
 	public String test(@RequestParam String str) {
 
-		if(str.contains("Illegal")){
+		if (str.contains("Illegal")) {
 			throw new IllegalArgumentException();
 		} else if (str.contains("user")) {
 			throw new CustomException(INVALID_INPUT_VALUE);

--- a/backend/src/main/java/com/project/Tamago/domain/BaseTimeEntity.java
+++ b/backend/src/main/java/com/project/Tamago/domain/BaseTimeEntity.java
@@ -1,22 +1,24 @@
 package com.project.Tamago.domain;
 
-import lombok.Getter;
+import java.time.LocalDateTime;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.EntityListeners;
-import javax.persistence.MappedSuperclass;
-import java.time.LocalDateTime;
+import lombok.Getter;
 
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {
 
-    @CreatedDate
-    private LocalDateTime createdDate;
+	@CreatedDate
+	private LocalDateTime createdDate;
 
-    @LastModifiedDate
-    private LocalDateTime updatedDate;
+	@LastModifiedDate
+	private LocalDateTime updatedDate;
 }

--- a/backend/src/main/java/com/project/Tamago/domain/Bookmark.java
+++ b/backend/src/main/java/com/project/Tamago/domain/Bookmark.java
@@ -1,26 +1,32 @@
 package com.project.Tamago.domain;
 
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class Bookmark {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "typing_id")
-    private Typing typing;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "typing_id")
+	private Typing typing;
 }

--- a/backend/src/main/java/com/project/Tamago/domain/Contact.java
+++ b/backend/src/main/java/com/project/Tamago/domain/Contact.java
@@ -1,27 +1,34 @@
 package com.project.Tamago.domain;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.validation.constraints.Size;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
-import javax.validation.constraints.Size;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class Contact {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
 
-    @Size(max = 100)
-    @Column(nullable = false)
-    private String message;
+	@Size(max = 100)
+	@Column(nullable = false)
+	private String message;
 }

--- a/backend/src/main/java/com/project/Tamago/domain/Register.java
+++ b/backend/src/main/java/com/project/Tamago/domain/Register.java
@@ -1,26 +1,32 @@
 package com.project.Tamago.domain;
 
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class Register {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "typing_id")
-    private Typing typing;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "typing_id")
+	private Typing typing;
 }

--- a/backend/src/main/java/com/project/Tamago/domain/Typing.java
+++ b/backend/src/main/java/com/project/Tamago/domain/Typing.java
@@ -1,33 +1,34 @@
 package com.project.Tamago.domain;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
-
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+
+import org.hibernate.annotations.ColumnDefault;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class Typing extends BaseTimeEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
 
-    private String language;
+	private String language;
 
-    private String content;
+	private String content;
 
-    private Integer length;
+	private Integer length;
 
-    private Integer viewCount;
+	private Integer viewCount;
 
-    @ColumnDefault("true")
-    private Boolean contentType;
+	@ColumnDefault("true")
+	private Boolean contentType;
 }

--- a/backend/src/main/java/com/project/Tamago/domain/TypingHistory.java
+++ b/backend/src/main/java/com/project/Tamago/domain/TypingHistory.java
@@ -1,35 +1,41 @@
 package com.project.Tamago.domain;
 
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class TypingHistory {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "typing_id")
-    private Typing typing;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "typing_id")
+	private Typing typing;
 
-    private Integer wpm;
+	private Integer wpm;
 
-    private Double accuracy;
+	private Double accuracy;
 
-    private Integer beforeMmr;
+	private Integer beforeMmr;
 
-    private Integer increasedValue;
+	private Integer increasedValue;
 
 }

--- a/backend/src/main/java/com/project/Tamago/domain/User.java
+++ b/backend/src/main/java/com/project/Tamago/domain/User.java
@@ -1,16 +1,23 @@
 package com.project.Tamago.domain;
 
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.validation.constraints.Size;
+
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+
 import com.project.Tamago.util.constant.Role;
 import com.project.Tamago.util.converter.RoleConverter;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.DynamicInsert;
-
-import javax.persistence.*;
-import javax.validation.constraints.Size;
 
 @Entity
 @DynamicInsert
@@ -18,36 +25,36 @@ import javax.validation.constraints.Size;
 @AllArgsConstructor
 @Builder
 public class User extends BaseTimeEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
 
-    @Column(nullable = false)
-    private String email;
+	@Column(nullable = false)
+	private String email;
 
-    @Column(nullable = false)
-    private String password;
+	@Column(nullable = false)
+	private String password;
 
-    @Column(length = 10, nullable = false, unique = true)
-    @Size(max = 10)
-    private String nickname;
+	@Column(length = 10, nullable = false, unique = true)
+	@Size(max = 10)
+	private String nickname;
 
-    @Size(max = 20)
-    private String introduce;
+	@Size(max = 20)
+	private String introduce;
 
-    private String profileImg;
+	private String profileImg;
 
-    @ColumnDefault("true")
-    private Boolean terms;
+	@ColumnDefault("true")
+	private Boolean terms;
 
-    @ColumnDefault("true")
-    private Boolean status;
+	@ColumnDefault("true")
+	private Boolean status;
 
-    @ColumnDefault("'none'")
-    private String provider;
+	@ColumnDefault("'none'")
+	private String provider;
 
-    private String providerId;
+	private String providerId;
 
-    @Convert(converter = RoleConverter.class)
-    private Role role;
+	@Convert(converter = RoleConverter.class)
+	private Role role;
 }

--- a/backend/src/main/java/com/project/Tamago/domain/User.java
+++ b/backend/src/main/java/com/project/Tamago/domain/User.java
@@ -1,5 +1,6 @@
 package com.project.Tamago.domain;
 
+import com.project.Tamago.util.constant.Role;
 import com.project.Tamago.util.converter.RoleConverter;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/backend/src/main/java/com/project/Tamago/exception/CustomException.java
+++ b/backend/src/main/java/com/project/Tamago/exception/CustomException.java
@@ -4,22 +4,22 @@ import com.project.Tamago.exception.exceptionHandler.ErrorCode;
 
 public class CustomException extends RuntimeException {
 
-    private ErrorCode errorCode;
+	private ErrorCode errorCode;
 
-    public CustomException() {
-        super();
-    }
+	public CustomException() {
+		super();
+	}
 
-    public CustomException(ErrorCode errorCode) {
-        super(errorCode.getDescription());
-        this.errorCode = errorCode;
-    }
+	public CustomException(ErrorCode errorCode) {
+		super(errorCode.getDescription());
+		this.errorCode = errorCode;
+	}
 
-    public CustomException(String message, Throwable cause) {
-        super(message, cause);
-    }
+	public CustomException(String message, Throwable cause) {
+		super(message, cause);
+	}
 
-    public ErrorCode getErrorCode() {
-        return errorCode;
-    }
+	public ErrorCode getErrorCode() {
+		return errorCode;
+	}
 }

--- a/backend/src/main/java/com/project/Tamago/exception/CustomException.java
+++ b/backend/src/main/java/com/project/Tamago/exception/CustomException.java
@@ -1,16 +1,25 @@
 package com.project.Tamago.exception;
 
-public class CustomException extends RuntimeException{
+import com.project.Tamago.exception.exceptionHandler.ErrorCode;
 
-	public CustomException() {
-		super();
-	}
+public class CustomException extends RuntimeException {
 
-	public CustomException(String message) {
-		super(message);
-	}
+    private ErrorCode errorCode;
 
-	public CustomException(String message, Throwable cause) {
-		super(message, cause);
-	}
+    public CustomException() {
+        super();
+    }
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getDescription());
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
 }

--- a/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ControllerAdvice.java
+++ b/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ControllerAdvice.java
@@ -18,8 +18,9 @@ public class ControllerAdvice {
 
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(CustomException.class)
-	public ErrorMessage userExceptionHandler(CustomException exception) {
-		return new ErrorMessage(ErrorCode.CUSTOM_PROBLEM);
+	public ErrorMessage customExceptionHandler(CustomException exception) {
+		ErrorCode errorCode = exception.getErrorCode();
+		return new ErrorMessage(errorCode);
 	}
 
 	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ControllerAdvice.java
+++ b/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.project.Tamago.exception.exceptionHandler;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -12,24 +13,24 @@ import com.project.Tamago.exception.CustomException;
 @RestControllerAdvice
 public class ControllerAdvice {
 
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ErrorMessage illegalArgumentExceptionHandler(IllegalArgumentException exception) {
-        return new ErrorMessage(ErrorCode.INVALID_INPUT_VALUE);
-    }
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ErrorMessage illegalArgumentExceptionHandler(IllegalArgumentException exception) {
+		return new ErrorMessage(ErrorCode.INVALID_INPUT_VALUE);
+	}
 
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler(CustomException.class)
-    public ErrorMessage customExceptionHandler(CustomException exception) {
-        ErrorCode errorCode = exception.getErrorCode();
-        log.error(errorCode.getDescription());
-        return new ErrorMessage(errorCode);
-    }
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(CustomException.class)
+	public ErrorMessage customExceptionHandler(CustomException exception) {
+		ErrorCode errorCode = exception.getErrorCode();
+		log.error(errorCode.getDescription());
+		return new ErrorMessage(errorCode);
+	}
 
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    @ExceptionHandler(Exception.class)
-    public ErrorMessage exceptionHandler(Exception exception) {
-        exception.printStackTrace();
-        return new ErrorMessage(ErrorCode.INTERNAL_SERVER_ERROR);
-    }
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	@ExceptionHandler(Exception.class)
+	public ErrorMessage exceptionHandler(Exception exception) {
+		exception.printStackTrace();
+		return new ErrorMessage(ErrorCode.INTERNAL_SERVER_ERROR);
+	}
 }

--- a/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ControllerAdvice.java
+++ b/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ControllerAdvice.java
@@ -1,5 +1,6 @@
 package com.project.Tamago.exception.exceptionHandler;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -7,26 +8,28 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.project.Tamago.exception.CustomException;
 
+@Slf4j
 @RestControllerAdvice
 public class ControllerAdvice {
 
-	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	@ExceptionHandler(IllegalArgumentException.class)
-	public ErrorMessage illegalArgumentExceptionHandler(IllegalArgumentException exception) {
-		return new ErrorMessage(ErrorCode.INVALID_INPUT_VALUE);
-	}
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ErrorMessage illegalArgumentExceptionHandler(IllegalArgumentException exception) {
+        return new ErrorMessage(ErrorCode.INVALID_INPUT_VALUE);
+    }
 
-	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	@ExceptionHandler(CustomException.class)
-	public ErrorMessage customExceptionHandler(CustomException exception) {
-		ErrorCode errorCode = exception.getErrorCode();
-		return new ErrorMessage(errorCode);
-	}
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(CustomException.class)
+    public ErrorMessage customExceptionHandler(CustomException exception) {
+        ErrorCode errorCode = exception.getErrorCode();
+        log.error(errorCode.getDescription());
+        return new ErrorMessage(errorCode);
+    }
 
-	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-	@ExceptionHandler(Exception.class)
-	public ErrorMessage exceptionHandler(Exception exception) {
-		exception.printStackTrace();
-		return new ErrorMessage(ErrorCode.INTERNAL_SERVER_ERROR);
-	}
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception.class)
+    public ErrorMessage exceptionHandler(Exception exception) {
+        exception.printStackTrace();
+        return new ErrorMessage(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
 }

--- a/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ErrorCode.java
+++ b/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ErrorCode.java
@@ -2,40 +2,27 @@ package com.project.Tamago.exception.exceptionHandler;
 
 public enum ErrorCode {
 
-	INVALID_INPUT_VALUE(400, "COMMON-001", "유효성 검증에 실패한 경우"),
-	INTERNAL_SERVER_ERROR(500, "COMMON-002", "서버에서 처리할 수 없는 경우"),
+    INVALID_INPUT_VALUE(400, "유효성 검증에 실패한 경우"),
+    INTERNAL_SERVER_ERROR(500, "서버에서 처리할 수 없는 경우"),
+    EXPIRED_JWT(2000, "만료된 JWT입니다."),
+    INVALID_SIGNATURE(2001, "유효하지 않은 서명입니다"),
+    INVALID_JWT(2002, "유효하지 않은 JWT입니다."),
+    UNSUPPORTED_JWT(2003, "지원하지않는 JWT입니다.");
 
-	DUPLICATE_LOGIN_ID(400, "ACCOUNT-001", "계정명이 중복된 경우"),
-	UNAUTHORIZED(401, "ACCOUNT-002", "인증에 실패한 경우"),
-	ACCOUNT_NOT_FOUND(404, "ACCOUNT-003", "계정을 찾을 수 없는 경우"),
-	ROLE_NOT_EXISTS(403, "ACCOUNT-004", "권한이 부족한 경우"),
-	TOKEN_NOT_EXISTS(404, "ACCOUNT-005", "해당 key의 인증 토큰이 존재하지 않는 경우"),
 
-	ARTIST_NOT_FOUND(404, "ARTIST-001", "가수를 찾을 수 없는 경우"),
+    private final int code;
+    private final String description;
 
-	CUSTOM_PROBLEM(444, "CUSTOM-001", "커스텀 에러(예시)"),
+    ErrorCode(int code, String description) {
+        this.code = code;
+        this.description = description;
+    }
 
-	CONTEST_INVALID_DATE(400, "CONTEST-001", "선정 곡 날짜가 적절치 않은 경우");
+    public int getCode() {
+        return code;
+    }
 
-	private final int status;
-	private final String code;
-	private final String description;
-
-	ErrorCode(int status, String code, String description) {
-		this.status = status;
-		this.code = code;
-		this.description = description;
-	}
-
-	public int getStatus() {
-		return status;
-	}
-
-	public String getCode() {
-		return code;
-	}
-
-	public String getDescription() {
-		return description;
-	}
+    public String getDescription() {
+        return description;
+    }
 }

--- a/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ErrorCode.java
+++ b/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ErrorCode.java
@@ -2,27 +2,26 @@ package com.project.Tamago.exception.exceptionHandler;
 
 public enum ErrorCode {
 
-    INVALID_INPUT_VALUE(400, "유효성 검증에 실패한 경우"),
-    INTERNAL_SERVER_ERROR(500, "서버에서 처리할 수 없는 경우"),
-    EXPIRED_JWT(2000, "만료된 JWT입니다."),
-    INVALID_SIGNATURE(2001, "유효하지 않은 서명입니다"),
-    INVALID_JWT(2002, "유효하지 않은 JWT입니다."),
-    UNSUPPORTED_JWT(2003, "지원하지않는 JWT입니다.");
+	INVALID_INPUT_VALUE(400, "유효성 검증에 실패한 경우"),
+	INTERNAL_SERVER_ERROR(500, "서버에서 처리할 수 없는 경우"),
+	EXPIRED_JWT(2000, "만료된 JWT입니다."),
+	INVALID_SIGNATURE(2001, "유효하지 않은 서명입니다"),
+	INVALID_JWT(2002, "유효하지 않은 JWT입니다."),
+	UNSUPPORTED_JWT(2003, "지원하지않는 JWT입니다.");
 
+	private final int code;
+	private final String description;
 
-    private final int code;
-    private final String description;
+	ErrorCode(int code, String description) {
+		this.code = code;
+		this.description = description;
+	}
 
-    ErrorCode(int code, String description) {
-        this.code = code;
-        this.description = description;
-    }
+	public int getCode() {
+		return code;
+	}
 
-    public int getCode() {
-        return code;
-    }
-
-    public String getDescription() {
-        return description;
-    }
+	public String getDescription() {
+		return description;
+	}
 }

--- a/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ErrorMessage.java
+++ b/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ErrorMessage.java
@@ -4,13 +4,10 @@ import lombok.Data;
 
 @Data
 public class ErrorMessage {
-
-	private int status;
-	private String code;
+	private int code;
 	private String description;
 
 	ErrorMessage(ErrorCode errorCode) {
-		this.status = errorCode.getStatus();
 		this.code = errorCode.getCode();
 		this.description = errorCode.getDescription();
 	}

--- a/backend/src/main/java/com/project/Tamago/jwt/JwtAuthorizationFilter.java
+++ b/backend/src/main/java/com/project/Tamago/jwt/JwtAuthorizationFilter.java
@@ -1,0 +1,4 @@
+package com.project.Tamago.jwt;
+
+public class JwtAuthorizationFilter {
+}

--- a/backend/src/main/java/com/project/Tamago/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/project/Tamago/jwt/JwtTokenProvider.java
@@ -79,12 +79,13 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public Authentication getAuthenticationFromToken(KeyType type, String token) {
+    public Authentication getAuthentication(String token) {
         Claims claims = Jwts.parserBuilder()
-                .setSigningKey(publicKeys.get(type))
+                .setSigningKey(publicKeys.get(KeyType.ACCESS))
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
+
         Collection<? extends GrantedAuthority> authorities =
                 Arrays.stream(claims.get(AUTHORITIES_KEY, String.class).split(","))
                         .map(SimpleGrantedAuthority::new)

--- a/backend/src/main/java/com/project/Tamago/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/project/Tamago/jwt/JwtTokenProvider.java
@@ -1,14 +1,23 @@
 package com.project.Tamago.jwt;
 
+import com.project.Tamago.util.constant.KeyType;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
 import java.security.Key;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -17,13 +26,18 @@ public class JwtTokenProvider {
 
     private static final String AUTHORITIES_KEY = "auth";
 
-    private Key accessKey;
-    private Key refreshKey;
+    private final Map<KeyType, Key> privateKeys = new EnumMap<>(KeyType.class);
+    private final Map<KeyType, Key> publicKeys = new EnumMap<>(KeyType.class);
+    private final Map<KeyType, Long> expireTimes = new EnumMap<>(KeyType.class);
 
-    @Value("${jwt.secret.access}")
-    private String accessSecretKey;
-    @Value("${jwt.secret.refresh}")
-    private String refreshSecretKey;
+    @Value("${jwt.private.access}")
+    private String privateAccessSecretKey; // encoded by base64
+    @Value("${jwt.public.access}")
+    private String publicAccessSecretKey; // encoded by base64
+    @Value("${jwt.private.refresh}")
+    private String privateRefreshSecretKey; // encoded by base64
+    @Value("${jwt.public.refresh}")
+    private String publicRefreshSecretKey; // encoded by base64
 
     @Value("${jwt.time.access}")
     private Long accessTokenExpireTime;
@@ -32,11 +46,93 @@ public class JwtTokenProvider {
 
     @PostConstruct
     public void initialize() {
-        accessKey = Keys.hmacShaKeyFor(getDecodedBytes(accessSecretKey));
-        refreshKey = Keys.hmacShaKeyFor(getDecodedBytes(refreshSecretKey));
+        privateKeys.put(KeyType.ACCESS, decodeKey(privateAccessSecretKey));
+        publicKeys.put(KeyType.ACCESS, decodeKey(publicAccessSecretKey));
+        privateKeys.put(KeyType.REFRESH, decodeKey(privateRefreshSecretKey));
+        publicKeys.put(KeyType.REFRESH, decodeKey(publicRefreshSecretKey));
+        expireTimes.put(KeyType.ACCESS, accessTokenExpireTime);
+        expireTimes.put(KeyType.REFRESH, refreshTokenExpireTime);
     }
 
-    private byte[] getDecodedBytes(String encodedSecretKey) {
-        return Decoders.BASE64.decode(encodedSecretKey);
+    private Key decodeKey(String encodedSecretKey) {
+        return Keys.hmacShaKeyFor(Decoders.BASE64.decode(encodedSecretKey));
+    }
+
+    private JwtBuilder createBuilder(KeyType type, Authentication authentication) {
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+        return Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim(AUTHORITIES_KEY, authorities)
+                .setExpiration(new Date(new Date().getTime() + expireTimes.get(type)))
+                .signWith(privateKeys.get(type), SignatureAlgorithm.RS256);
+    }
+    public String createAccessToken(Authentication authentication) {
+        return createBuilder(KeyType.ACCESS, authentication).compact();
+    }
+
+    public String createRefreshToken(Authentication authentication) {
+        return createBuilder(KeyType.REFRESH, authentication).compact();
+    }
+
+    private Authentication getAuthenticationFromToken(KeyType type, String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(publicKeys.get(type))
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get(AUTHORITIES_KEY, String.class).split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        return new UsernamePasswordAuthenticationToken(claims.getSubject(), token, authorities);
+    }
+
+    public Long getExpiration(String accessToken) {
+        // accessToken 남은 유효시간
+        Date expiration = Jwts.parserBuilder()
+                .setSigningKey(publicKeys.get(KeyType.ACCESS))
+                .build()
+                .parseClaimsJws(accessToken)
+                .getBody()
+                .getExpiration();
+        // 현재 시간
+        Date now = new Date();
+        return (expiration.getTime() - now.getTime());
+    }
+
+    public boolean validateAccessToken(String accessToken) throws IllegalArgumentException {
+        return validateToken(KeyType.ACCESS,accessToken);
+    }
+
+    public boolean validateRefreshToken(String refreshToken) throws IllegalArgumentException {
+        return validateToken(KeyType.REFRESH, refreshToken);
+    }
+
+    private boolean validateToken(KeyType type, String token) {
+        try {
+            Jwts
+                    .parserBuilder().setSigningKey(publicKeys.get(type)).build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token.");
+            log.trace("Expired JWT token trace: {}", e);
+        } catch (MalformedJwtException e) {
+            log.error("Invalid JWT token.");
+            log.trace("Invalid JWT token trace: {}", e);
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token.");
+            log.trace("Unsupported JWT token trace: {}", e);
+        } catch (SignatureException e) {
+            log.error("Invalid JWT signature.");
+            log.trace("Invalid JWT signature trace: {}", e);
+        } catch (IllegalArgumentException e) {
+            log.error("JWT token compact of handler are invalid.");
+            log.trace("JWT token compact of handler are invalid trace: {}", e);
+        }
+        return false;
     }
 }

--- a/backend/src/main/java/com/project/Tamago/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/project/Tamago/jwt/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package com.project.Tamago.jwt;
 
+import com.project.Tamago.exception.CustomException;
 import com.project.Tamago.util.constant.KeyType;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
@@ -18,6 +19,8 @@ import javax.annotation.PostConstruct;
 import java.security.*;
 import java.util.*;
 import java.util.stream.Collectors;
+
+import static com.project.Tamago.exception.exceptionHandler.ErrorCode.*;
 
 @Slf4j
 @Component
@@ -120,21 +123,16 @@ public class JwtTokenProvider {
                     .parserBuilder().setSigningKey(publicKeys.get(type)).build()
                     .parseClaimsJws(token);
             return true;
-        } catch (ExpiredJwtException e) {
-            log.error("Expired JWT token.");
-            log.trace("Expired JWT token trace: {}", e);
-        } catch (MalformedJwtException e) {
-            log.error("Invalid JWT token.");
-            log.trace("Invalid JWT token trace: {}", e);
-        } catch (UnsupportedJwtException e) {
-            log.error("Unsupported JWT token.");
-            log.trace("Unsupported JWT token trace: {}", e);
         } catch (SignatureException e) {
-            log.error("Invalid JWT signature.");
-            log.trace("Invalid JWT signature trace: {}", e);
+            throw new CustomException(INVALID_SIGNATURE);
+        } catch (MalformedJwtException e) {
+            throw new CustomException(INVALID_JWT);
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(EXPIRED_JWT);
+        } catch (UnsupportedJwtException e) {
+            throw new CustomException(UNSUPPORTED_JWT);
         } catch (IllegalArgumentException e) {
             log.error("JWT token compact of handler are invalid.");
-            log.trace("JWT token compact of handler are invalid trace: {}", e);
         }
         return false;
     }

--- a/backend/src/main/java/com/project/Tamago/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/project/Tamago/jwt/JwtTokenProvider.java
@@ -1,0 +1,42 @@
+package com.project.Tamago.jwt;
+
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.security.Key;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private static final String AUTHORITIES_KEY = "auth";
+
+    private Key accessKey;
+    private Key refreshKey;
+
+    @Value("${jwt.secret.access}")
+    private String accessSecretKey;
+    @Value("${jwt.secret.refresh}")
+    private String refreshSecretKey;
+
+    @Value("${jwt.time.access}")
+    private Long accessTokenExpireTime;
+    @Value("${jwt.time.refresh}")
+    private Long refreshTokenExpireTime;
+
+    @PostConstruct
+    public void initialize() {
+        accessKey = Keys.hmacShaKeyFor(getDecodedBytes(accessSecretKey));
+        refreshKey = Keys.hmacShaKeyFor(getDecodedBytes(refreshSecretKey));
+    }
+
+    private byte[] getDecodedBytes(String encodedSecretKey) {
+        return Decoders.BASE64.decode(encodedSecretKey);
+    }
+}

--- a/backend/src/main/java/com/project/Tamago/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/project/Tamago/jwt/JwtTokenProvider.java
@@ -1,13 +1,21 @@
 package com.project.Tamago.jwt;
 
-import com.project.Tamago.exception.CustomException;
-import com.project.Tamago.util.constant.KeyType;
-import io.jsonwebtoken.*;
-import io.jsonwebtoken.io.Decoders;
-import io.jsonwebtoken.security.Keys;
-import io.jsonwebtoken.security.SignatureException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import static com.project.Tamago.exception.exceptionHandler.ErrorCode.*;
+
+import java.security.Key;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -15,125 +23,131 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
-import java.security.*;
-import java.util.*;
-import java.util.stream.Collectors;
+import com.project.Tamago.exception.CustomException;
+import com.project.Tamago.util.constant.KeyType;
 
-import static com.project.Tamago.exception.exceptionHandler.ErrorCode.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtTokenProvider {
 
-    private static final String AUTHORITIES_KEY = "auth";
-    private final Map<KeyType, Key> privateKeys = new EnumMap<>(KeyType.class);
-    private final Map<KeyType, Key> publicKeys = new EnumMap<>(KeyType.class);
-    private final Map<KeyType, Long> expireTimes = new EnumMap<>(KeyType.class);
+	private static final String AUTHORITIES_KEY = "auth";
+	private final Map<KeyType, Key> privateKeys = new EnumMap<>(KeyType.class);
+	private final Map<KeyType, Key> publicKeys = new EnumMap<>(KeyType.class);
+	private final Map<KeyType, Long> expireTimes = new EnumMap<>(KeyType.class);
 
-    @Value("${jwt.time.access}")
-    private Long accessTokenExpireTime;
-    @Value("${jwt.time.refresh}")
-    private Long refreshTokenExpireTime;
+	@Value("${jwt.time.access}")
+	private Long accessTokenExpireTime;
+	@Value("${jwt.time.refresh}")
+	private Long refreshTokenExpireTime;
 
-    @PostConstruct
-    public void initialize() {
-        KeyPair accessKeyPair = generateRSAKeyPair();
-        KeyPair refreshKeyPair = generateRSAKeyPair();
+	@PostConstruct
+	public void initialize() {
+		KeyPair accessKeyPair = generateRSAKeyPair();
+		KeyPair refreshKeyPair = generateRSAKeyPair();
 
-        privateKeys.put(KeyType.ACCESS, accessKeyPair.getPrivate());
-        publicKeys.put(KeyType.ACCESS, accessKeyPair.getPublic());
-        privateKeys.put(KeyType.REFRESH, refreshKeyPair.getPrivate());
-        publicKeys.put(KeyType.REFRESH, refreshKeyPair.getPublic());
+		privateKeys.put(KeyType.ACCESS, accessKeyPair.getPrivate());
+		publicKeys.put(KeyType.ACCESS, accessKeyPair.getPublic());
+		privateKeys.put(KeyType.REFRESH, refreshKeyPair.getPrivate());
+		publicKeys.put(KeyType.REFRESH, refreshKeyPair.getPublic());
 
-        expireTimes.put(KeyType.ACCESS, accessTokenExpireTime);
-        expireTimes.put(KeyType.REFRESH, refreshTokenExpireTime);
-    }
+		expireTimes.put(KeyType.ACCESS, accessTokenExpireTime);
+		expireTimes.put(KeyType.REFRESH, refreshTokenExpireTime);
+	}
 
-    private KeyPair generateRSAKeyPair() {
-        try {
-            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
-            generator.initialize(2048, new SecureRandom());
-            return generator.generateKeyPair();
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("Failed to generate RSA key pair", e);
-        }
-    }
+	private KeyPair generateRSAKeyPair() {
+		try {
+			KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+			generator.initialize(2048, new SecureRandom());
+			return generator.generateKeyPair();
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException("Failed to generate RSA key pair", e);
+		}
+	}
 
-    public String createAccessToken(Authentication authentication) {
-        return createBuilder(KeyType.ACCESS, authentication);
-    }
+	public String createAccessToken(Authentication authentication) {
+		return createBuilder(KeyType.ACCESS, authentication);
+	}
 
-    public String createRefreshToken(Authentication authentication) {
-        return createBuilder(KeyType.REFRESH, authentication);
-    }
+	public String createRefreshToken(Authentication authentication) {
+		return createBuilder(KeyType.REFRESH, authentication);
+	}
 
-    private String createBuilder(KeyType type, Authentication authentication) {
-        String authorities = authentication.getAuthorities().stream()
-                .map(GrantedAuthority::getAuthority)
-                .collect(Collectors.joining(","));
+	private String createBuilder(KeyType type, Authentication authentication) {
+		String authorities = authentication.getAuthorities().stream()
+			.map(GrantedAuthority::getAuthority)
+			.collect(Collectors.joining(","));
 
-        return Jwts.builder()
-                .setSubject(authentication.getName())
-                .claim(AUTHORITIES_KEY, authorities)
-                .setExpiration(new Date(new Date().getTime() + expireTimes.get(type)))
-                .signWith(privateKeys.get(type), SignatureAlgorithm.RS256)
-                .compact();
-    }
+		return Jwts.builder()
+			.setSubject(authentication.getName())
+			.claim(AUTHORITIES_KEY, authorities)
+			.setExpiration(new Date(new Date().getTime() + expireTimes.get(type)))
+			.signWith(privateKeys.get(type), SignatureAlgorithm.RS256)
+			.compact();
+	}
 
-    public Authentication getAuthentication(String token) {
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(publicKeys.get(KeyType.ACCESS))
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
+	public Authentication getAuthentication(String token) {
+		Claims claims = Jwts.parserBuilder()
+			.setSigningKey(publicKeys.get(KeyType.ACCESS))
+			.build()
+			.parseClaimsJws(token)
+			.getBody();
 
-        Collection<? extends GrantedAuthority> authorities =
-                Arrays.stream(claims.get(AUTHORITIES_KEY, String.class).split(","))
-                        .map(SimpleGrantedAuthority::new)
-                        .collect(Collectors.toList());
+		Collection<? extends GrantedAuthority> authorities =
+			Arrays.stream(claims.get(AUTHORITIES_KEY, String.class).split(","))
+				.map(SimpleGrantedAuthority::new)
+				.collect(Collectors.toList());
 
-        return new UsernamePasswordAuthenticationToken(claims.getSubject(), token, authorities);
-    }
+		return new UsernamePasswordAuthenticationToken(claims.getSubject(), token, authorities);
+	}
 
-    public Long getExpiration(String accessToken) {
-        Date expiration = Jwts.parserBuilder()
-                .setSigningKey(publicKeys.get(KeyType.ACCESS))
-                .build()
-                .parseClaimsJws(accessToken)
-                .getBody()
-                .getExpiration();
+	public Long getExpiration(String accessToken) {
+		Date expiration = Jwts.parserBuilder()
+			.setSigningKey(publicKeys.get(KeyType.ACCESS))
+			.build()
+			.parseClaimsJws(accessToken)
+			.getBody()
+			.getExpiration();
 
-        Date now = new Date();
-        return (expiration.getTime() - now.getTime());
-    }
+		Date now = new Date();
+		return (expiration.getTime() - now.getTime());
+	}
 
-    public boolean validateAccessToken(String accessToken) throws IllegalArgumentException {
-        return validateToken(KeyType.ACCESS, accessToken);
-    }
+	public boolean validateAccessToken(String accessToken) throws IllegalArgumentException {
+		return validateToken(KeyType.ACCESS, accessToken);
+	}
 
-    public boolean validateRefreshToken(String refreshToken) throws IllegalArgumentException {
-        return validateToken(KeyType.REFRESH, refreshToken);
-    }
+	public boolean validateRefreshToken(String refreshToken) throws IllegalArgumentException {
+		return validateToken(KeyType.REFRESH, refreshToken);
+	}
 
-    private boolean validateToken(KeyType type, String token) {
-        try {
-            Jwts
-                    .parserBuilder().setSigningKey(publicKeys.get(type)).build()
-                    .parseClaimsJws(token);
-            return true;
-        } catch (SignatureException e) {
-            throw new CustomException(INVALID_SIGNATURE);
-        } catch (MalformedJwtException e) {
-            throw new CustomException(INVALID_JWT);
-        } catch (ExpiredJwtException e) {
-            throw new CustomException(EXPIRED_JWT);
-        } catch (UnsupportedJwtException e) {
-            throw new CustomException(UNSUPPORTED_JWT);
-        } catch (IllegalArgumentException e) {
-            log.error("JWT token compact of handler are invalid.");
-        }
-        return false;
-    }
+	private boolean validateToken(KeyType type, String token) {
+		try {
+			Jwts
+				.parserBuilder().setSigningKey(publicKeys.get(type)).build()
+				.parseClaimsJws(token);
+			return true;
+		} catch (SignatureException e) {
+			throw new CustomException(INVALID_SIGNATURE);
+		} catch (MalformedJwtException e) {
+			throw new CustomException(INVALID_JWT);
+		} catch (ExpiredJwtException e) {
+			throw new CustomException(EXPIRED_JWT);
+		} catch (UnsupportedJwtException e) {
+			throw new CustomException(UNSUPPORTED_JWT);
+		} catch (IllegalArgumentException e) {
+			log.error("JWT token compact of handler are invalid.");
+		}
+		return false;
+	}
 }

--- a/backend/src/main/java/com/project/Tamago/jwt/handler/CustomAccessDeniedHandler.java
+++ b/backend/src/main/java/com/project/Tamago/jwt/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,4 @@
+package com.project.Tamago.jwt.handler;
+
+public class CustomAccessDeniedHandler {
+}

--- a/backend/src/main/java/com/project/Tamago/jwt/handler/CustomAuthenticationEntryPointHandler.java
+++ b/backend/src/main/java/com/project/Tamago/jwt/handler/CustomAuthenticationEntryPointHandler.java
@@ -1,0 +1,4 @@
+package com.project.Tamago.jwt.handler;
+
+public class CustomAuthenticationEntryPointHandler {
+}

--- a/backend/src/main/java/com/project/Tamago/util/constant/KeyType.java
+++ b/backend/src/main/java/com/project/Tamago/util/constant/KeyType.java
@@ -1,0 +1,8 @@
+package com.project.Tamago.util.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum KeyType {
+    ACCESS,REFRESH
+}

--- a/backend/src/main/java/com/project/Tamago/util/constant/KeyType.java
+++ b/backend/src/main/java/com/project/Tamago/util/constant/KeyType.java
@@ -4,5 +4,5 @@ import lombok.Getter;
 
 @Getter
 public enum KeyType {
-    ACCESS,REFRESH
+	ACCESS, REFRESH
 }

--- a/backend/src/main/java/com/project/Tamago/util/constant/Role.java
+++ b/backend/src/main/java/com/project/Tamago/util/constant/Role.java
@@ -1,26 +1,26 @@
 package com.project.Tamago.util.constant;
 
-import lombok.Getter;
-
 import java.util.Arrays;
+
+import lombok.Getter;
 
 @Getter
 public enum Role {
 
-    USER("유저", "ROLE_USER"), ADMIN("관리자", "ROLE_ADMIN");
+	USER("유저", "ROLE_USER"), ADMIN("관리자", "ROLE_ADMIN");
 
-    private final String desc;
-    private final String type;
+	private final String desc;
+	private final String type;
 
-    Role(String desc, String type) {
-        this.desc = desc;
-        this.type = type;
-    }
+	Role(String desc, String type) {
+		this.desc = desc;
+		this.type = type;
+	}
 
-    public static Role ofType(String type) {
-        return Arrays.stream(Role.values())
-                .filter(v -> v.getType().equals(type))
-                .findAny()
-                .orElseThrow(() -> new IllegalArgumentException(String.format("ROLE에 type=[%s]가 존재하지 않습니다.", type)));
-    }
+	public static Role ofType(String type) {
+		return Arrays.stream(Role.values())
+			.filter(v -> v.getType().equals(type))
+			.findAny()
+			.orElseThrow(() -> new IllegalArgumentException(String.format("ROLE에 type=[%s]가 존재하지 않습니다.", type)));
+	}
 }

--- a/backend/src/main/java/com/project/Tamago/util/constant/Role.java
+++ b/backend/src/main/java/com/project/Tamago/util/constant/Role.java
@@ -1,7 +1,6 @@
-package com.project.Tamago.domain;
+package com.project.Tamago.util.constant;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
 

--- a/backend/src/main/java/com/project/Tamago/util/converter/RoleConverter.java
+++ b/backend/src/main/java/com/project/Tamago/util/converter/RoleConverter.java
@@ -1,10 +1,9 @@
 package com.project.Tamago.util.converter;
 
-import com.project.Tamago.domain.Role;
+import com.project.Tamago.util.constant.Role;
 
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
-import java.util.Arrays;
 
 @Converter
 public class RoleConverter implements AttributeConverter<Role, String> {

--- a/backend/src/main/java/com/project/Tamago/util/converter/RoleConverter.java
+++ b/backend/src/main/java/com/project/Tamago/util/converter/RoleConverter.java
@@ -1,20 +1,20 @@
 package com.project.Tamago.util.converter;
 
-import com.project.Tamago.util.constant.Role;
-
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
+
+import com.project.Tamago.util.constant.Role;
 
 @Converter
 public class RoleConverter implements AttributeConverter<Role, String> {
 
-    @Override
-    public String convertToDatabaseColumn(Role attribute) {
-        return attribute.getType();
-    }
+	@Override
+	public String convertToDatabaseColumn(Role attribute) {
+		return attribute.getType();
+	}
 
-    @Override
-    public Role convertToEntityAttribute(String dbData) {
-        return Role.ofType(dbData);
-    }
+	@Override
+	public Role convertToEntityAttribute(String dbData) {
+		return Role.ofType(dbData);
+	}
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -23,7 +23,10 @@ spring:
         format_sql:
 
 jwt:
-  secret:
+  private:
+    access:
+    refresh:
+  public:
     access:
     refresh:
   time:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -23,12 +23,6 @@ spring:
         format_sql:
 
 jwt:
-  private:
-    access:
-    refresh:
-  public:
-    access:
-    refresh:
   time:
     access:
     refresh:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -21,3 +21,12 @@ spring:
     properties:
       hibernate:
         format_sql:
+
+jwt:
+  secret:
+    access:
+    refresh:
+  time:
+    access:
+    refresh:
+


### PR DESCRIPTION
## 📄 구현 내용 설명

### ⛱️ 주요 변경 사항

- 인증 구현에 한 부분인 jwtTokenProvider
- jwt토큰을 생성하고 유효성을 검증하는 jwtTokenProvider를 작성했습니다
- 암호화 방식을 고민하다 대칭키 방식보다는 공개키암호화 방식의 안전성 + 도전욕구때문에 rsa방식으로 구현했습니다(밑에 참고 사이트 봐주세요)
- error handler의 status랑 code를 하나로 합쳤습니다
- 인증, 인가 전부를 pr올리려했지만 리뷰할 양이 너무 많아지고 무거울거같아서 jwtTokenProvider먼저 구현해서 pr합니다

### 🙋 이 부분을 리뷰해주세요

- 메소드 중복, 지나친 길이, 상수설정 및 연관성있는 상수의 enum 변환 등을 고려했습니다

### 🤔 여기를 참고하면 도움이 돼요

- [jwt 기본 참고](https://junyharang.tistory.com/188)
- [jwt 기본 참고2](https://velog.io/@ellie12/Auth-%EC%9D%B8%EC%A6%9D)
- [jwt 기본 참고3 해싱](https://junyharang.tistory.com/97?category=959876)
- [base64 참고1](https://warpgate3.tistory.com/entry/Base64-Encoding)
- [base64 참고2](https://codingpractices.tistory.com/entry/Base64-%EC%9D%B8%EC%BD%94%EB%94%A9%EC%9D%B4%EB%9E%80-%EC%A0%95%ED%99%95%ED%95%98%EA%B2%8C-%EC%9D%B4%ED%95%B4%ED%95%98%EA%B8%B0)
- [인코딩 방법](https://linuxhint.com/bash_base64_encode_decode/)
- [내가 hmac이 아닌 rsa를 쓴이유](https://medium.com/jongho-developer/jwt-algorithm-hs256-rs256-1ab9f833c486)
- [jwtTokenProvider를 보기전에 참고했으면하는 것](https://escapefromcoding.tistory.com/255)
