### PR TITLE
[#17] 인증, 인가 처리 fiter class 구현 및 security 적용

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -40,8 +40,8 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '2.7.8'
-	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'java'
+    id 'org.springframework.boot' version '2.7.8'
+    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 }
 
 group = 'com.project'
@@ -9,41 +9,44 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
 
-	// Swagger
-	implementation ('io.springfox:springfox-boot-starter:3.0.0')
+    // Swagger
+    implementation('io.springfox:springfox-boot-starter:3.0.0')
 
-	// jwt
-	implementation('io.jsonwebtoken:jjwt-api:0.11.5')
-	implementation('io.jsonwebtoken:jjwt-impl:0.11.5')
-	implementation('io.jsonwebtoken:jjwt-jackson:0.11.5')
+    // jwt
+    implementation('io.jsonwebtoken:jjwt-api:0.11.5')
+    implementation('io.jsonwebtoken:jjwt-impl:0.11.5')
+    implementation('io.jsonwebtoken:jjwt-jackson:0.11.5')
 
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/backend/src/main/java/com/project/Tamago/config/RedisConfig.java
+++ b/backend/src/main/java/com/project/Tamago/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.project.Tamago.config;
+
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+	private final RedisProperties redisProperties;
+
+	// Lettuce
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+	}
+
+	// RedisTemplate
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate() {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		return redisTemplate;
+	}
+}

--- a/backend/src/main/java/com/project/Tamago/config/SecurityConfig.java
+++ b/backend/src/main/java/com/project/Tamago/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.project.Tamago.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 public class SecurityConfig {
 
 	private final CorsConfig corsConfig;
+	private final RedisTemplate<String, Object> redisTemplate;
 
 	@Bean
 	public SecurityFilterChain apiFilterChain(HttpSecurity http) throws Exception {

--- a/backend/src/main/java/com/project/Tamago/config/SecurityConfig.java
+++ b/backend/src/main/java/com/project/Tamago/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import com.project.Tamago.jwt.JwtAuthorizationFilter;
 import com.project.Tamago.jwt.JwtTokenProvider;
 import com.project.Tamago.jwt.handler.CustomAccessDeniedHandler;
+import com.project.Tamago.jwt.handler.CustomAuthenticationEntryPointHandler;
 
 import lombok.RequiredArgsConstructor;
 
@@ -39,7 +40,8 @@ public class SecurityConfig {
 		http
 			.addFilter(corsConfig.corsFilter())
 			.exceptionHandling()
-			.accessDeniedHandler(new CustomAccessDeniedHandler()); // 인가 예외 처리
+			.authenticationEntryPoint(new CustomAuthenticationEntryPointHandler())
+			.accessDeniedHandler(new CustomAccessDeniedHandler());
 		http
 			.authorizeRequests()
 			// swagger

--- a/backend/src/main/java/com/project/Tamago/config/SecurityConfig.java
+++ b/backend/src/main/java/com/project/Tamago/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
 			.authorizeRequests()
 			// swagger
 			.antMatchers("/auth/**").permitAll()
+			.antMatchers("/test/**").permitAll()
 			.antMatchers("/swagger-ui/**").permitAll()
 			.antMatchers("/swagger-ui.html").permitAll()
 			.antMatchers("/swagger/**").permitAll()

--- a/backend/src/main/java/com/project/Tamago/controller/TestController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TestController.java
@@ -13,7 +13,6 @@ public class TestController {
 
 	@GetMapping("/test")
 	public String test(@RequestParam String str) {
-		System.out.println("hi");
 		if (str.contains("Illegal")) {
 			throw new IllegalArgumentException();
 		} else if (str.contains("user")) {

--- a/backend/src/main/java/com/project/Tamago/controller/TestController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TestController.java
@@ -13,7 +13,7 @@ public class TestController {
 
 	@GetMapping("/test")
 	public String test(@RequestParam String str) {
-
+		System.out.println("hi");
 		if (str.contains("Illegal")) {
 			throw new IllegalArgumentException();
 		} else if (str.contains("user")) {

--- a/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ErrorCode.java
+++ b/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ErrorCode.java
@@ -7,7 +7,8 @@ public enum ErrorCode {
 	EXPIRED_JWT(2000, "만료된 JWT입니다."),
 	INVALID_SIGNATURE(2001, "유효하지 않은 서명입니다"),
 	INVALID_JWT(2002, "유효하지 않은 JWT입니다."),
-	UNSUPPORTED_JWT(2003, "지원하지않는 JWT입니다.");
+	UNSUPPORTED_JWT(2003, "지원하지않는 JWT입니다."),
+	INVALID_USER_JWT(2004, "권한이 없는 유저의 접근입니다.");
 
 	private final int code;
 	private final String description;

--- a/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ErrorCode.java
+++ b/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ErrorCode.java
@@ -8,7 +8,8 @@ public enum ErrorCode {
 	INVALID_SIGNATURE(2001, "유효하지 않은 서명입니다"),
 	INVALID_JWT(2002, "유효하지 않은 JWT입니다."),
 	UNSUPPORTED_JWT(2003, "지원하지않는 JWT입니다."),
-	INVALID_USER_JWT(2004, "권한이 없는 유저의 접근입니다.");
+	INVALID_USER_JWT(2004, "권한이 없는 유저의 접근입니다."),
+	EMPTY_JWT(2005, "JWT를 입력해주세요.");
 
 	private final int code;
 	private final String description;

--- a/backend/src/main/java/com/project/Tamago/jwt/JwtAuthorizationFilter.java
+++ b/backend/src/main/java/com/project/Tamago/jwt/JwtAuthorizationFilter.java
@@ -1,4 +1,46 @@
 package com.project.Tamago.jwt;
 
-public class JwtAuthorizationFilter {
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+		throws IOException, ServletException {
+
+		String token = jwtTokenProvider.resolveToken(request);
+
+		if (token != null && jwtTokenProvider.validateAccessToken(token)) {
+
+			String isLogout = (String)redisTemplate.opsForValue().get(token);
+			if (ObjectUtils.isEmpty(isLogout)) {
+
+				Authentication authentication = jwtTokenProvider.getAuthentication(token);
+				String nickname = authentication.getName();
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+
+				request.setAttribute("nickname", nickname);
+			}
+		}
+		chain.doFilter(request, response);
+	}
 }

--- a/backend/src/main/java/com/project/Tamago/jwt/JwtAuthorizationFilter.java
+++ b/backend/src/main/java/com/project/Tamago/jwt/JwtAuthorizationFilter.java
@@ -29,7 +29,6 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
 		throws IOException, ServletException {
-
 		String token = jwtTokenProvider.resolveToken(request);
 
 		if (!StringUtils.hasText(token)) {
@@ -39,7 +38,6 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 		}
 		try {
 			if (jwtTokenProvider.validateAccessToken(token)) {
-
 				String isLogout = (String)redisTemplate.opsForValue().get(token);
 				if (ObjectUtils.isEmpty(isLogout)) {
 

--- a/backend/src/main/java/com/project/Tamago/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/project/Tamago/jwt/JwtTokenProvider.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -42,6 +43,7 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtTokenProvider {
 
 	private static final String AUTHORITIES_KEY = "auth";
+	public static final String AUTHORIZATION_HEADER = "Authorization";
 	private final Map<KeyType, Key> privateKeys = new EnumMap<>(KeyType.class);
 	private final Map<KeyType, Key> publicKeys = new EnumMap<>(KeyType.class);
 	private final Map<KeyType, Long> expireTimes = new EnumMap<>(KeyType.class);
@@ -149,5 +151,9 @@ public class JwtTokenProvider {
 			log.error("JWT token compact of handler are invalid.");
 		}
 		return false;
+	}
+
+	public String resolveToken(HttpServletRequest request) {
+		return request.getHeader(AUTHORIZATION_HEADER);
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/project/Tamago/jwt/JwtTokenProvider.java
@@ -106,6 +106,10 @@ public class JwtTokenProvider {
 		return validateToken(KeyType.ACCESS, accessToken);
 	}
 
+	public String resolveToken(HttpServletRequest request) {
+		return request.getHeader(AUTHORIZATION_HEADER);
+	}
+
 	private KeyPair generateRSAKeyPair() {
 		try {
 			KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
@@ -151,9 +155,5 @@ public class JwtTokenProvider {
 			log.error("JWT token compact of handler are invalid.");
 		}
 		return false;
-	}
-
-	public String resolveToken(HttpServletRequest request) {
-		return request.getHeader(AUTHORIZATION_HEADER);
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/jwt/handler/CustomAccessDeniedHandler.java
+++ b/backend/src/main/java/com/project/Tamago/jwt/handler/CustomAccessDeniedHandler.java
@@ -25,7 +25,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 		response.setContentType("application/json;charset=UTF-8");
 		response.getWriter().write("{" + "\"isSuccess\":false, "
 			+ "\"code\":\"" + INVALID_USER_JWT.getCode() + "\","
-			+ "\"message\":\"" + INVALID_USER_JWT.getDescription() + "\"}");
+			+ "\"description\":\"" + INVALID_USER_JWT.getDescription() + "\"}");
 		response.getWriter().flush();
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/jwt/handler/CustomAccessDeniedHandler.java
+++ b/backend/src/main/java/com/project/Tamago/jwt/handler/CustomAccessDeniedHandler.java
@@ -1,4 +1,31 @@
 package com.project.Tamago.jwt.handler;
 
-public class CustomAccessDeniedHandler {
+import static com.project.Tamago.exception.exceptionHandler.ErrorCode.*;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+	@Override
+	public void handle(
+		HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws
+		IOException,
+		ServletException {
+		log.info(INVALID_USER_JWT.getDescription());
+		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+		response.setContentType("application/json;charset=UTF-8");
+		response.getWriter().write("{" + "\"isSuccess\":false, "
+			+ "\"code\":\"" + INVALID_USER_JWT.getCode() + "\","
+			+ "\"message\":\"" + INVALID_USER_JWT.getDescription() + "\"}");
+		response.getWriter().flush();
+	}
 }

--- a/backend/src/main/java/com/project/Tamago/jwt/handler/CustomAuthenticationEntryPointHandler.java
+++ b/backend/src/main/java/com/project/Tamago/jwt/handler/CustomAuthenticationEntryPointHandler.java
@@ -1,4 +1,0 @@
-package com.project.Tamago.jwt.handler;
-
-public class CustomAuthenticationEntryPointHandler {
-}

--- a/backend/src/main/java/com/project/Tamago/jwt/handler/CustomAuthenticationEntryPointHandler.java
+++ b/backend/src/main/java/com/project/Tamago/jwt/handler/CustomAuthenticationEntryPointHandler.java
@@ -1,0 +1,46 @@
+package com.project.Tamago.jwt.handler;
+
+import static com.project.Tamago.exception.exceptionHandler.ErrorCode.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import com.project.Tamago.exception.exceptionHandler.ErrorCode;
+
+public class CustomAuthenticationEntryPointHandler implements AuthenticationEntryPoint {
+	private final ErrorCode[] errorCodes = {EMPTY_JWT, EXPIRED_JWT, INVALID_JWT};
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) throws IOException,
+		ServletException {
+		String exception = String.valueOf(request.getAttribute("exception"));
+
+		ErrorCode errorCode = Arrays.stream(errorCodes)
+			.filter(ec -> exception.equals(ec.getCode() + ""))
+			.findFirst()
+			.orElse(null);
+
+		if (errorCode != null) {
+			setResponse(response, errorCode);
+		}
+		if (exception.isEmpty()) {
+			setResponse(response, EMPTY_JWT);
+		}
+	}
+
+	private void setResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.setContentType("application/json;charset=UTF-8");
+		response.getWriter().write("{" + "\"code\":\"" + errorCode.getCode() + "\","
+			+ "\"message\":\"" + errorCode.getDescription() + "\"}");
+		response.getWriter().flush();
+	}
+}

--- a/backend/src/main/java/com/project/Tamago/jwt/handler/CustomAuthenticationEntryPointHandler.java
+++ b/backend/src/main/java/com/project/Tamago/jwt/handler/CustomAuthenticationEntryPointHandler.java
@@ -40,7 +40,7 @@ public class CustomAuthenticationEntryPointHandler implements AuthenticationEntr
 		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 		response.setContentType("application/json;charset=UTF-8");
 		response.getWriter().write("{" + "\"code\":\"" + errorCode.getCode() + "\","
-			+ "\"message\":\"" + errorCode.getDescription() + "\"}");
+			+ "\"description\":\"" + errorCode.getDescription() + "\"}");
 		response.getWriter().flush();
 	}
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -22,6 +22,12 @@ spring:
       hibernate:
         format_sql:
 
+  cache:
+    type:
+  redis:
+    host:
+    port:
+
 jwt:
   time:
     access:

--- a/backend/src/test/java/com/project/Tamago/jwt/JwtAuthorizationFilterTest.java
+++ b/backend/src/test/java/com/project/Tamago/jwt/JwtAuthorizationFilterTest.java
@@ -1,0 +1,43 @@
+package com.project.Tamago.jwt;
+
+import static com.project.Tamago.exception.exceptionHandler.ErrorCode.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.project.Tamago.exception.CustomException;
+
+@ExtendWith(SpringExtension.class)
+class JwtAuthorizationFilterTest {
+
+	private JwtAuthorizationFilter filter;
+
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+	private final String INVALID_TOKEN = "invalidToken";
+
+	@DisplayName("유효하지 않은 토큰 검증 테스트")
+	@Test
+	public void invalidTokenTest() throws Exception {
+		try {
+			jwtTokenProvider.validateAccessToken(INVALID_TOKEN);
+		} catch (CustomException e) {
+			assertEquals(e.getErrorCode().getCode(), INVALID_JWT.getCode());
+		}
+	}
+
+	@DisplayName("토큰값이 비어있을때 테스트")
+	@Test
+	public void emptyTokenTest() throws Exception {
+		String token = null;
+		try {
+			jwtTokenProvider.validateAccessToken(token);
+		} catch (CustomException e) {
+			assertEquals(e.getErrorCode().getCode(), EMPTY_JWT.getCode());
+		}
+	}
+}

--- a/backend/src/test/java/com/project/Tamago/jwt/JwtAuthorizationFilterTest.java
+++ b/backend/src/test/java/com/project/Tamago/jwt/JwtAuthorizationFilterTest.java
@@ -13,9 +13,7 @@ import com.project.Tamago.exception.CustomException;
 
 @ExtendWith(SpringExtension.class)
 class JwtAuthorizationFilterTest {
-
-	private JwtAuthorizationFilter filter;
-
+	
 	@Mock
 	private JwtTokenProvider jwtTokenProvider;
 	private final String INVALID_TOKEN = "invalidToken";


### PR DESCRIPTION
## 📄 구현 내용 설명

### ⛱️ 주요 변경 사항

- 인증 및 인가 처리를 하는 jwtAuthorizationfilter를 구현했습니다
- security에서 해당 필터를 거치고 권한이없는(관리자만 들어갈수있는곳에 일반유저가 들어간다거나)CustomAccessDeniedHandler로 넘기는 식으로 구현 완성했습니다
- redis 적용했습니다 (반드시 참고 링크를 보셔야합니다 - 로컬환경에서 설치 및 이해를 위해)

### 🙋 이 부분을 리뷰해주세요

- notion에 yml 참고
-

### 🤔 여기를 참고하면 도움이 돼요

-  [redis를 로컬에서 쓰기위해서](https://inpa.tistory.com/entry/REDIS-%F0%9F%93%9A-Window10-%ED%99%98%EA%B2%BD%EC%97%90-Redis-%EC%84%A4%EC%B9%98%ED%95%98%EA%B8%B0)
- [redis 구현](https://wildeveloperetrain.tistory.com/32)
- [인증과 인가란](https://velog.io/@chyoon0512/%EC%9D%B8%EC%A6%9D%EC%9D%B8%EA%B0%80-%EB%9E%80-JWTJSON-web-token)
- [jwtAuthorizationfilter](https://hipopatamus.tistory.com/72)
- [아 어려워](https://imbf.github.io/spring/2020/06/29/Spring-Security-with-JWT.html)