### PR TITLE
[#32] 커스텀 체크박스를 구현했습니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .idea
-node_modules

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,6 @@
         "javascriptreact",
         "typescript",
         "typescriptreact"
-    ]
+    ],
+    "editor.tabSize": 2
 }

--- a/client/.storybook/main.js
+++ b/client/.storybook/main.js
@@ -1,15 +1,16 @@
 module.exports = {
-  "stories": [
-    "../src/**/*.stories.mdx",
-    "../src/**/*.stories.@(js|jsx|ts|tsx)"
+  stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  addons: [
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-interactions',
+    '@chakra-ui/storybook-addon',
   ],
-  "addons": [
-    "@storybook/addon-links",
-    "@storybook/addon-essentials",
-    "@storybook/addon-interactions"
-  ],
-  "framework": "@storybook/react",
-  "core": {
-    "builder": "@storybook/builder-webpack5"
-  }
-}
+  features: {
+    emotionAlias: false,
+  },
+  framework: '@storybook/react',
+  core: {
+    builder: '@storybook/builder-webpack5',
+  },
+};

--- a/client/.storybook/preview.js
+++ b/client/.storybook/preview.js
@@ -1,9 +1,13 @@
+// import theme from '../src/styles/theme';
+// import Button from '../src/styles/Button';
+// const theme = require('../src/styles/theme');
+
 export const parameters = {
-  actions: { argTypesRegex: "^on[A-Z].*" },
+  actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {
     matchers: {
       color: /(background|color)$/i,
       date: /Date$/,
     },
   },
-}
+};

--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",
+    "@chakra-ui/storybook-addon": "^4.0.16",
     "@next/eslint-plugin-next": "^13.1.6",
     "@storybook/addon-actions": "^6.5.16",
     "@storybook/addon-essentials": "^6.5.16",

--- a/client/src/assets/icons/checkbox-check.svg
+++ b/client/src/assets/icons/checkbox-check.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="9" viewBox="0 0 12 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.87988 4.72785L4.54312 7.40381L10.1193 1.80103" stroke="#FF8A65" stroke-width="2.10572" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/src/components/common/Checkbox/index.stories.tsx
+++ b/client/src/components/common/Checkbox/index.stories.tsx
@@ -9,12 +9,16 @@ export default {
   component: CustomCheckbox,
 } as ComponentMeta<typeof CustomCheckbox>;
 
-const Template: ComponentStory<typeof CustomCheckbox> = () => {
+const Template: ComponentStory<typeof CustomCheckbox> = (args) => {
   return (
     <ChakraProvider theme={theme}>
-      <CustomCheckbox />
+      <CustomCheckbox {...args} />
     </ChakraProvider>
   );
 };
 
 export const CheckboxTemplate: ComponentStory<typeof CustomCheckbox> = Template.bind({});
+
+CheckboxTemplate.args = {
+  labelText: '테스트 텍스트입니다',
+};

--- a/client/src/components/common/Checkbox/index.stories.tsx
+++ b/client/src/components/common/Checkbox/index.stories.tsx
@@ -1,0 +1,20 @@
+import { ChakraProvider } from '@chakra-ui/react';
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import theme from '../../../styles/theme';
+import { CustomCheckbox } from '.';
+
+export default {
+  title: 'components/common/checkbox',
+  component: CustomCheckbox,
+} as ComponentMeta<typeof CustomCheckbox>;
+
+const Template: ComponentStory<typeof CustomCheckbox> = () => {
+  return (
+    <ChakraProvider theme={theme}>
+      <CustomCheckbox />
+    </ChakraProvider>
+  );
+};
+
+export const CheckboxTemplate: ComponentStory<typeof CustomCheckbox> = Template.bind({});

--- a/client/src/components/common/Checkbox/index.tsx
+++ b/client/src/components/common/Checkbox/index.tsx
@@ -4,7 +4,7 @@ import { useCheckbox } from '@chakra-ui/react';
 
 const CheckedIcon = () => {
   return (
-    <Icon viewBox='0 0 12 9' fill='none' xmlns='http://www.w3.org/2000/svg'>
+    <Icon viewBox='0 0 12 9' fill='none' xmlns='http://www.w3.org/2000/svg' w='12px'>
       <path
         d='M1.87988 4.72785L4.54312 7.40381L10.1193 1.80103'
         stroke='#FF8A65'
@@ -16,7 +16,12 @@ const CheckedIcon = () => {
   );
 };
 
-export const CustomCheckbox = (props: UseCheckboxProps) => {
+interface CheckboxProps {
+  labelText: string;
+}
+
+export const CustomCheckbox = (props: UseCheckboxProps & CheckboxProps) => {
+  const { labelText } = props;
   const { state, getCheckboxProps, getInputProps, getLabelProps, htmlProps } = useCheckbox(props);
   return (
     <FormLabel
@@ -37,12 +42,14 @@ export const CustomCheckbox = (props: UseCheckboxProps) => {
         borderRadius='5px'
         w='20px'
         h='20px'
+        mx='5px'
+        my='6px'
         {...getCheckboxProps()}
       >
         {state.isChecked && <CheckedIcon />}
       </Flex>
       <Text size='15px' {...getLabelProps()}>
-        custom checkbox
+        {labelText}
       </Text>
     </FormLabel>
   );

--- a/client/src/components/common/Checkbox/index.tsx
+++ b/client/src/components/common/Checkbox/index.tsx
@@ -17,7 +17,7 @@ const CheckedIcon = () => {
 };
 
 interface CheckboxProps {
-  labelText: string;
+  labelText?: string;
 }
 
 export const CustomCheckbox = (props: UseCheckboxProps & CheckboxProps) => {
@@ -28,7 +28,7 @@ export const CustomCheckbox = (props: UseCheckboxProps & CheckboxProps) => {
       display='flex'
       alignItems='center'
       borderColor='secondary.100'
-      gap='14px'
+      gap={labelText ? '14px' : '0'}
       cursor='pointer'
       {...htmlProps}
     >

--- a/client/src/components/common/Checkbox/index.tsx
+++ b/client/src/components/common/Checkbox/index.tsx
@@ -1,0 +1,49 @@
+import type { UseCheckboxProps } from '@chakra-ui/react';
+import { Flex, FormLabel, Icon, Text } from '@chakra-ui/react';
+import { useCheckbox } from '@chakra-ui/react';
+
+const CheckedIcon = () => {
+  return (
+    <Icon viewBox='0 0 12 9' fill='none' xmlns='http://www.w3.org/2000/svg'>
+      <path
+        d='M1.87988 4.72785L4.54312 7.40381L10.1193 1.80103'
+        stroke='#FF8A65'
+        strokeWidth='2.10572'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </Icon>
+  );
+};
+
+export const CustomCheckbox = (props: UseCheckboxProps) => {
+  const { state, getCheckboxProps, getInputProps, getLabelProps, htmlProps } = useCheckbox(props);
+  return (
+    <FormLabel
+      display='flex'
+      alignItems='center'
+      borderColor='secondary.100'
+      gap='14px'
+      cursor='pointer'
+      {...htmlProps}
+    >
+      <input {...getInputProps()} hidden />
+      <Flex
+        alignItems='center'
+        justifyContent='center'
+        bg='white'
+        border='0.6px solid'
+        borderColor='tamago.500'
+        borderRadius='5px'
+        w='20px'
+        h='20px'
+        {...getCheckboxProps()}
+      >
+        {state.isChecked && <CheckedIcon />}
+      </Flex>
+      <Text size='15px' {...getLabelProps()}>
+        custom checkbox
+      </Text>
+    </FormLabel>
+  );
+};

--- a/client/src/styles/theme.ts
+++ b/client/src/styles/theme.ts
@@ -1,7 +1,7 @@
 import type { StyleConfig } from '@chakra-ui/react';
 import { extendTheme } from '@chakra-ui/react';
 
-import { buttonTheme } from '@/styles/Button';
+import { buttonTheme } from '../styles/Button';
 
 export interface FontBorderTheme {
   fontFamily: string;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1794,6 +1794,11 @@
     "@chakra-ui/react-context" "2.0.7"
     "@chakra-ui/shared-utils" "2.0.5"
 
+"@chakra-ui/storybook-addon@^4.0.16":
+  version "4.0.16"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/storybook-addon/-/storybook-addon-4.0.16.tgz#6e2c1c6c92aa50eda6db412fd53cce5088e3e514"
+  integrity sha512-4+Mm9WHl+2lZ6BFTRV9xE+vT6Gxh0cvtScOw7idvhPru1vzTiJVsSpHoWANzQAs08DAzwulexjLghCMGnLKKhw==
+
 "@chakra-ui/styled-system@2.5.2":
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/@chakra-ui/styled-system/-/styled-system-2.5.2.tgz#f0dfcc3efac9a4428ca548840062d479d2a909a1"


### PR DESCRIPTION
close #32

## 📄 구현 내용 설명
커스텀 체크박스를 구현했습니다.

<div display='flex'>
  <img width="161" alt="Screenshot 2023-02-12 at 6 07 55 PM" src="https://user-images.githubusercontent.com/59170680/218302238-0e1aad6d-011a-4014-9d94-83773913811b.png">
  <img width="161" alt="Screenshot 2023-02-12 at 6 09 11 PM" src="https://user-images.githubusercontent.com/59170680/218302291-c4f91755-78df-4248-bcfc-57fc9284cbaa.png">
</div>


### ⛱️ 주요 변경 사항

- [`components > common > Checkbox`](https://github.com/msdio/Tamago/blob/74633b1d81c57d5d025a66b800465ad07782e912/client/src/components/common/Checkbox/index.tsx) 에 커스텀 체크박스를 구현했습니다. 차크라에서 제공하는 기능을 최대한 사용하기 위해, 바닐라 대신 차크라에서 제공하는 `useCheckbox`훅을 사용했습니다.<br/>
사용할 때에는 아래와 같이 사용하면 됩니다!
```jsx
...
<CustomCheckbox labelText='여기에 텍스트를 입력' />
...
```

작동 방식은 아래와 같습니다
> 1. 커스텀한 체크박스 이미지를 들고 있는 `Flexbox`와, 이와 연결된 숨겨진 `input checkbox`를 label로 만듭니다.
> 2. 체크박스를 클릭하면, 실제로는 `input checkbox`가 클릭되고, 해당 클릭 정보를 `flexbox`로 보내 체크 아이콘을 띄울지 결정합니다.

- 같은 디렉토리에 [체크박스 컴포넌트의 스토리](https://github.com/msdio/Tamago/blob/74633b1d81c57d5d025a66b800465ad07782e912/client/src/components/common/Checkbox/index.stories.tsx#LL1)를 작성했습니다. `yarn storybook`으로 실행하면, 6006번 포트에서 스토리를 확인할 수 있을 거에요. 컴포넌트 개발 후 스토리를 작성할 때에는 해당 파일을 참고해서 작성해주세요!

- 스토리북에 차크라UI에서 커스텀한 스타일을 적용하기 위해, `@chakra-ui/storybook-addon`를 설치했습니다.

<br/>

### 🙋 이 부분을 리뷰해주세요

- 최상위 디렉토리에 있던 gitignore에 node_module를 제거했습니다. 다음번에 커밋할 때 node modules가 지워졌는지 한번 더 확인해주세요!  @sumi-0011
- 지금은 체크박스와 텍스트를 하나로 묶어서 만들었는데, 텍스트는 따로 분리하고 체크박스 자체만 컴포넌트로 만드는게 나을까요?
- 찾아보니 차크라UI에서는 svg 파일들을 [이런식으로](https://github.com/msdio/Tamago/blob/74633b1d81c57d5d025a66b800465ad07782e912/client/src/components/common/Checkbox/index.tsx#L5) 사용하고 있는 것 같아서, 같은 방식으로 사용했습니다. 더 괜찮은 방법이 있다면 알려주세요!

<br/>

### 🤔 여기를 참고하면 도움이 돼요

-   [useCheckbox in Chakra UI](https://chakra-ui.com/docs/hooks/use-checkbox)
-  [chakra UI storybook addon](https://www.npmjs.com/package/@chakra-ui/storybook-addon?activeTab=readme)
