### PR TITLE
[#66] user profile API 구현

### DIFF
--- a/backend/src/main/java/com/project/Tamago/config/SecurityConfig.java
+++ b/backend/src/main/java/com/project/Tamago/config/SecurityConfig.java
@@ -47,6 +47,10 @@ public class SecurityConfig {
 			.authenticationEntryPoint(new CustomAuthenticationEntryPointHandler())
 			.accessDeniedHandler(new CustomAccessDeniedHandler());
 		http
+			.headers()
+			.frameOptions()
+			.sameOrigin();
+		http
 			.authorizeRequests()
 			// swagger
 			.antMatchers("/auth/**").permitAll()
@@ -57,6 +61,7 @@ public class SecurityConfig {
 			.antMatchers("/swagger-resources/**").permitAll()
 			.antMatchers("/v2/api-docs").permitAll()
 			.antMatchers("/health").permitAll()
+			.antMatchers("/h2-console/**").permitAll()
 			.and()
 			.authorizeRequests()
 			.anyRequest().authenticated();

--- a/backend/src/main/java/com/project/Tamago/controller/AuthController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/AuthController.java
@@ -1,17 +1,16 @@
 package com.project.Tamago.controller;
 
-import javax.validation.Valid;
-
 import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.project.Tamago.dto.requestDto.JoinReqDto;
-import com.project.Tamago.dto.requestDto.LoginReqDto;
 import com.project.Tamago.dto.SuccessMessage;
 import com.project.Tamago.dto.TokenDto;
+import com.project.Tamago.dto.requestDto.JoinReqDto;
+import com.project.Tamago.dto.requestDto.LoginReqDto;
 import com.project.Tamago.exception.InvalidParameterException;
 import com.project.Tamago.service.AuthService;
 
@@ -27,7 +26,7 @@ public class AuthController {
 	private final AuthService authService;
 
 	@PostMapping("/join")
-	public SuccessMessage join(@Valid @RequestBody JoinReqDto joinReqDto, BindingResult result) {
+	public SuccessMessage join(@Validated @RequestBody JoinReqDto joinReqDto, BindingResult result) {
 		if (result.hasErrors()) {
 			throw new InvalidParameterException(result);
 		}

--- a/backend/src/main/java/com/project/Tamago/controller/AuthController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/AuthController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.project.Tamago.dto.requestDto.JoinReqDto;
 import com.project.Tamago.dto.requestDto.LoginReqDto;
-import com.project.Tamago.dto.SuccessResDto;
+import com.project.Tamago.dto.SuccessMessage;
 import com.project.Tamago.dto.TokenDto;
 import com.project.Tamago.exception.InvalidParameterException;
 import com.project.Tamago.service.AuthService;
@@ -27,12 +27,12 @@ public class AuthController {
 	private final AuthService authService;
 
 	@PostMapping("/join")
-	public SuccessResDto join(@Valid @RequestBody JoinReqDto joinReqDto, BindingResult result) {
+	public SuccessMessage join(@Valid @RequestBody JoinReqDto joinReqDto, BindingResult result) {
 		if (result.hasErrors()) {
 			throw new InvalidParameterException(result);
 		}
 		authService.join(joinReqDto);
-		return new SuccessResDto();
+		return new SuccessMessage();
 	}
 
 	@PostMapping("/login")

--- a/backend/src/main/java/com/project/Tamago/controller/AuthController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/AuthController.java
@@ -1,6 +1,5 @@
 package com.project.Tamago.controller;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
 import org.springframework.validation.BindingResult;
@@ -9,8 +8,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.project.Tamago.dto.JoinReqDto;
-import com.project.Tamago.dto.LoginReqDto;
+import com.project.Tamago.dto.requestDto.JoinReqDto;
+import com.project.Tamago.dto.requestDto.LoginReqDto;
 import com.project.Tamago.dto.SuccessResDto;
 import com.project.Tamago.dto.TokenDto;
 import com.project.Tamago.exception.InvalidParameterException;

--- a/backend/src/main/java/com/project/Tamago/controller/UserController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/UserController.java
@@ -1,7 +1,12 @@
 package com.project.Tamago.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.project.Tamago.dto.responseDto.ProfileResDto;
+import com.project.Tamago.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -10,5 +15,10 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/user")
 public class UserController {
 
+	private final UserService userService;
 
+	@GetMapping("/profile")
+	public ProfileResDto findProfile(@RequestHeader("Authorization") String jwtToken) {
+		return userService.findProfileByJwtToken(jwtToken);
+	}
 }

--- a/backend/src/main/java/com/project/Tamago/controller/UserController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.project.Tamago.controller;
 
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,7 +29,7 @@ public class UserController {
 
 	@PatchMapping("/profile")
 	public SuccessMessage modifyProfile(@RequestHeader("Authorization") String jwtToken,
-		@RequestBody ModifyProfileReqDto modifyProfileReqDto) {
+		@Validated @RequestBody ModifyProfileReqDto modifyProfileReqDto) {
 		userService.modifyUserByJwtToken(jwtToken, modifyProfileReqDto);
 		return new SuccessMessage();
 	}

--- a/backend/src/main/java/com/project/Tamago/controller/UserController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/UserController.java
@@ -1,0 +1,14 @@
+package com.project.Tamago.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user")
+public class UserController {
+
+
+}

--- a/backend/src/main/java/com/project/Tamago/controller/UserController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.project.Tamago.controller;
 
+import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.project.Tamago.dto.SuccessMessage;
 import com.project.Tamago.dto.requestDto.ModifyProfileReqDto;
 import com.project.Tamago.dto.responseDto.ProfileResDto;
+import com.project.Tamago.exception.InvalidParameterException;
 import com.project.Tamago.service.UserService;
 
 import lombok.RequiredArgsConstructor;
@@ -29,7 +31,10 @@ public class UserController {
 
 	@PatchMapping("/profile")
 	public SuccessMessage modifyProfile(@RequestHeader("Authorization") String jwtToken,
-		@Validated @RequestBody ModifyProfileReqDto modifyProfileReqDto) {
+		@Validated @RequestBody ModifyProfileReqDto modifyProfileReqDto, BindingResult result) {
+		if (result.hasErrors()) {
+			throw new InvalidParameterException(result);
+		}
 		userService.modifyUserByJwtToken(jwtToken, modifyProfileReqDto);
 		return new SuccessMessage();
 	}

--- a/backend/src/main/java/com/project/Tamago/controller/UserController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/UserController.java
@@ -1,10 +1,14 @@
 package com.project.Tamago.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.project.Tamago.dto.SuccessMessage;
+import com.project.Tamago.dto.requestDto.ModifyProfileReqDto;
 import com.project.Tamago.dto.responseDto.ProfileResDto;
 import com.project.Tamago.service.UserService;
 
@@ -20,5 +24,12 @@ public class UserController {
 	@GetMapping("/profile")
 	public ProfileResDto findProfile(@RequestHeader("Authorization") String jwtToken) {
 		return userService.findProfileByJwtToken(jwtToken);
+	}
+
+	@PatchMapping("/profile")
+	public SuccessMessage modifyProfile(@RequestHeader("Authorization") String jwtToken,
+		@RequestBody ModifyProfileReqDto modifyProfileReqDto) {
+		userService.modifyUserByJwtToken(jwtToken, modifyProfileReqDto);
+		return new SuccessMessage();
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/domain/User.java
+++ b/backend/src/main/java/com/project/Tamago/domain/User.java
@@ -12,6 +12,7 @@ import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import com.project.Tamago.dto.requestDto.ModifyProfileReqDto;
 import com.project.Tamago.util.constants.Role;
 import com.project.Tamago.util.converter.RoleConverter;
 
@@ -63,5 +64,10 @@ public class User extends BaseTimeEntity {
 
 	public void encodePassword(PasswordEncoder passwordEncoder, String password) {
 		this.password = passwordEncoder.encode(password);
+	}
+
+	public void modifyUserInfo(ModifyProfileReqDto modifyProfileReqDto) {
+		this.profileImg = modifyProfileReqDto.getProfileImg();
+		this.introduce = modifyProfileReqDto.getIntroduce();
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/dto/SuccessMessage.java
+++ b/backend/src/main/java/com/project/Tamago/dto/SuccessMessage.java
@@ -3,6 +3,7 @@ package com.project.Tamago.dto;
 import lombok.Data;
 
 @Data
-public class SuccessResDto {
+public class SuccessMessage {
 	private int code = 1000;
+	private String description = "응답 성공";
 }

--- a/backend/src/main/java/com/project/Tamago/dto/requestDto/JoinReqDto.java
+++ b/backend/src/main/java/com/project/Tamago/dto/requestDto/JoinReqDto.java
@@ -1,4 +1,4 @@
-package com.project.Tamago.dto;
+package com.project.Tamago.dto.requestDto;
 
 import javax.validation.constraints.Size;
 

--- a/backend/src/main/java/com/project/Tamago/dto/requestDto/LoginReqDto.java
+++ b/backend/src/main/java/com/project/Tamago/dto/requestDto/LoginReqDto.java
@@ -1,4 +1,4 @@
-package com.project.Tamago.dto;
+package com.project.Tamago.dto.requestDto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/backend/src/main/java/com/project/Tamago/dto/requestDto/ModifyProfileReqDto.java
+++ b/backend/src/main/java/com/project/Tamago/dto/requestDto/ModifyProfileReqDto.java
@@ -1,0 +1,13 @@
+package com.project.Tamago.dto.requestDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ModifyProfileReqDto {
+	private String introduce;
+	private String profileImg;
+}

--- a/backend/src/main/java/com/project/Tamago/dto/requestDto/ModifyProfileReqDto.java
+++ b/backend/src/main/java/com/project/Tamago/dto/requestDto/ModifyProfileReqDto.java
@@ -1,5 +1,8 @@
 package com.project.Tamago.dto.requestDto;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,6 +11,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ModifyProfileReqDto {
+
+	@Size(max = 20, message = "자기소개는 20자 이하입니다.")
 	private String introduce;
+
+	@NotNull
 	private String profileImg;
 }

--- a/backend/src/main/java/com/project/Tamago/dto/responseDto/ProfileResDto.java
+++ b/backend/src/main/java/com/project/Tamago/dto/responseDto/ProfileResDto.java
@@ -1,4 +1,26 @@
-package com.project.Tamago.dto;
+package com.project.Tamago.dto.responseDto;
 
-public class ProfileResDto {
+import com.project.Tamago.domain.User;
+import com.project.Tamago.dto.SuccessResDto;
+
+import lombok.Data;
+
+@Data
+public class ProfileResDto extends SuccessResDto {
+
+	private String email;
+	private String nickname;
+	private String introduce;
+	private String profileImg;
+	private Boolean terms;
+	private String provider;
+
+	public ProfileResDto(User user) {
+		email = user.getEmail();
+		nickname = user.getNickname();
+		introduce = user.getIntroduce();
+		profileImg = user.getProfileImg();
+		terms = user.getTerms();
+		provider = user.getProvider();
+	}
 }

--- a/backend/src/main/java/com/project/Tamago/dto/responseDto/ProfileResDto.java
+++ b/backend/src/main/java/com/project/Tamago/dto/responseDto/ProfileResDto.java
@@ -1,12 +1,12 @@
 package com.project.Tamago.dto.responseDto;
 
 import com.project.Tamago.domain.User;
-import com.project.Tamago.dto.SuccessResDto;
+import com.project.Tamago.dto.SuccessMessage;
 
 import lombok.Data;
 
 @Data
-public class ProfileResDto extends SuccessResDto {
+public class ProfileResDto extends SuccessMessage {
 
 	private String email;
 	private String nickname;

--- a/backend/src/main/java/com/project/Tamago/dto/responseDto/ProfileResDto.java
+++ b/backend/src/main/java/com/project/Tamago/dto/responseDto/ProfileResDto.java
@@ -1,0 +1,4 @@
+package com.project.Tamago.dto;
+
+public class ProfileResDto {
+}

--- a/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ControllerAdvice.java
+++ b/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ControllerAdvice.java
@@ -1,19 +1,20 @@
 package com.project.Tamago.exception.exceptionHandler;
 
+import static com.project.Tamago.exception.exceptionHandler.ErrorCode.*;
+
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import lombok.extern.slf4j.Slf4j;
-
-import static com.project.Tamago.exception.exceptionHandler.ErrorCode.*;
-
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.project.Tamago.exception.CustomException;
 import com.project.Tamago.exception.InvalidParameterException;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
@@ -40,6 +41,13 @@ public class ControllerAdvice {
 		ErrorCode errorCode = exception.getErrorCode();
 		log.error(errorCode.getDescription());
 		return new ErrorMessage(errorCode);
+	}
+
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ErrorMessage customExceptionHandler(MethodArgumentNotValidException exception) {
+		log.error(INVALID_PARAMETER.getDescription());
+		return new ErrorMessage(INVALID_PARAMETER);
 	}
 
 	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ErrorCode.java
+++ b/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ErrorCode.java
@@ -14,7 +14,7 @@ public enum ErrorCode {
 	USERS_EMPTY_USER_EMAIL(3000, "유저 이메일 값을 확인해주세요."),
 	USERS_EXISTS_EMAIL(3001, "중복된 이메일입니다."),
 	USERS_EXISTS_NICKNAME(3002, "중복된 닉네임입니다."),
-
+	USERS_INFO_NOT_EXISTS(3003, "유저 정보가 존재하지 않습니다."),
 	;
 
 	private final int code;

--- a/backend/src/main/java/com/project/Tamago/mapper/UserMapper.java
+++ b/backend/src/main/java/com/project/Tamago/mapper/UserMapper.java
@@ -1,2 +1,11 @@
-package com.project.Tamago.mapper;public class UserMapper {
+package com.project.Tamago.mapper;
+
+import com.project.Tamago.domain.User;
+import com.project.Tamago.dto.responseDto.ProfileResDto;
+
+public class UserMapper {
+
+	public static ProfileResDto convertProfileResDto(User user) {
+		return new ProfileResDto(user);
+	}
 }

--- a/backend/src/main/java/com/project/Tamago/mapper/UserMapper.java
+++ b/backend/src/main/java/com/project/Tamago/mapper/UserMapper.java
@@ -1,0 +1,2 @@
+package com.project.Tamago.mapper;public class UserMapper {
+}

--- a/backend/src/main/java/com/project/Tamago/repository/UserRepository.java
+++ b/backend/src/main/java/com/project/Tamago/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Integer> {
 
 	Boolean existsByNickname(String nickname);
 
+	Optional<User> findByNickname(String nickname);
+
 }

--- a/backend/src/main/java/com/project/Tamago/service/AuthService.java
+++ b/backend/src/main/java/com/project/Tamago/service/AuthService.java
@@ -11,8 +11,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.project.Tamago.domain.User;
-import com.project.Tamago.dto.JoinReqDto;
-import com.project.Tamago.dto.LoginReqDto;
+import com.project.Tamago.dto.requestDto.JoinReqDto;
+import com.project.Tamago.dto.requestDto.LoginReqDto;
 import com.project.Tamago.dto.TokenDto;
 import com.project.Tamago.exception.CustomException;
 import com.project.Tamago.jwt.JwtTokenProvider;

--- a/backend/src/main/java/com/project/Tamago/service/PrincipalDetailService.java
+++ b/backend/src/main/java/com/project/Tamago/service/PrincipalDetailService.java
@@ -9,7 +9,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.project.Tamago.domain.PrincipalDetails;
+import com.project.Tamago.util.security.PrincipalDetails;
 import com.project.Tamago.domain.User;
 import com.project.Tamago.exception.CustomException;
 import com.project.Tamago.repository.UserRepository;

--- a/backend/src/main/java/com/project/Tamago/service/UserService.java
+++ b/backend/src/main/java/com/project/Tamago/service/UserService.java
@@ -1,2 +1,33 @@
-package com.project.Tamago.service;public class UserService {
+package com.project.Tamago.service;
+
+import static com.project.Tamago.exception.exceptionHandler.ErrorCode.*;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+import com.project.Tamago.domain.User;
+import com.project.Tamago.dto.responseDto.ProfileResDto;
+import com.project.Tamago.exception.CustomException;
+import com.project.Tamago.jwt.JwtTokenProvider;
+import com.project.Tamago.mapper.UserMapper;
+import com.project.Tamago.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+	private final UserRepository userRepository;
+	private final JwtTokenProvider jwtTokenProvider;
+
+	public ProfileResDto findProfileByJwtToken(String jwtToken) {
+		Authentication authentication = jwtTokenProvider.getAuthentication(jwtToken);
+		User user = userRepository.findByNickname(authentication.getName())
+			.orElseThrow(() -> new CustomException(USERS_INFO_NOT_EXISTS));
+		return UserMapper.convertProfileResDto(user);
+	}
+
 }

--- a/backend/src/main/java/com/project/Tamago/service/UserService.java
+++ b/backend/src/main/java/com/project/Tamago/service/UserService.java
@@ -2,7 +2,6 @@ package com.project.Tamago.service;
 
 import static com.project.Tamago.exception.exceptionHandler.ErrorCode.*;
 
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,8 +34,7 @@ public class UserService {
 	}
 
 	private User getUserByJwtToken(String jwtToken) {
-		Authentication authentication = jwtTokenProvider.getAuthentication(jwtToken);
-		User user = userRepository.findByNickname(authentication.getName())
+		User user = userRepository.findByNickname(jwtTokenProvider.getAuthentication(jwtToken).getName())
 			.orElseThrow(() -> new CustomException(USERS_INFO_NOT_EXISTS));
 		return user;
 	}

--- a/backend/src/main/java/com/project/Tamago/service/UserService.java
+++ b/backend/src/main/java/com/project/Tamago/service/UserService.java
@@ -1,0 +1,2 @@
+package com.project.Tamago.service;public class UserService {
+}

--- a/backend/src/main/java/com/project/Tamago/service/UserService.java
+++ b/backend/src/main/java/com/project/Tamago/service/UserService.java
@@ -25,6 +25,7 @@ public class UserService {
 	private final UserRepository userRepository;
 	private final JwtTokenProvider jwtTokenProvider;
 
+	@Transactional(readOnly = true)
 	public ProfileResDto findProfileByJwtToken(String jwtToken) {
 		return UserMapper.convertProfileResDto(getUserByJwtToken(jwtToken));
 	}
@@ -34,8 +35,7 @@ public class UserService {
 	}
 
 	private User getUserByJwtToken(String jwtToken) {
-		User user = userRepository.findByNickname(jwtTokenProvider.getAuthentication(jwtToken).getName())
+		return userRepository.findByNickname(jwtTokenProvider.getAuthentication(jwtToken).getName())
 			.orElseThrow(() -> new CustomException(USERS_INFO_NOT_EXISTS));
-		return user;
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/service/UserService.java
+++ b/backend/src/main/java/com/project/Tamago/service/UserService.java
@@ -4,8 +4,10 @@ import static com.project.Tamago.exception.exceptionHandler.ErrorCode.*;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.project.Tamago.domain.User;
+import com.project.Tamago.dto.requestDto.ModifyProfileReqDto;
 import com.project.Tamago.dto.responseDto.ProfileResDto;
 import com.project.Tamago.exception.CustomException;
 import com.project.Tamago.jwt.JwtTokenProvider;
@@ -18,16 +20,24 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class UserService {
 
 	private final UserRepository userRepository;
 	private final JwtTokenProvider jwtTokenProvider;
 
 	public ProfileResDto findProfileByJwtToken(String jwtToken) {
+		return UserMapper.convertProfileResDto(getUserByJwtToken(jwtToken));
+	}
+
+	public void modifyUserByJwtToken(String jwtToken, ModifyProfileReqDto modifyProfileReqDto) {
+		getUserByJwtToken(jwtToken).modifyUserInfo(modifyProfileReqDto);
+	}
+
+	private User getUserByJwtToken(String jwtToken) {
 		Authentication authentication = jwtTokenProvider.getAuthentication(jwtToken);
 		User user = userRepository.findByNickname(authentication.getName())
 			.orElseThrow(() -> new CustomException(USERS_INFO_NOT_EXISTS));
-		return UserMapper.convertProfileResDto(user);
+		return user;
 	}
-
 }

--- a/backend/src/main/java/com/project/Tamago/util/security/PrincipalDetails.java
+++ b/backend/src/main/java/com/project/Tamago/util/security/PrincipalDetails.java
@@ -1,4 +1,4 @@
-package com.project.Tamago.domain;
+package com.project.Tamago.util.security;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -7,6 +7,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.project.Tamago.domain.User;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/backend/src/test/java/com/project/Tamago/TamagoApplicationTests.java
+++ b/backend/src/test/java/com/project/Tamago/TamagoApplicationTests.java
@@ -31,27 +31,4 @@ class TamagoApplicationTests {
 			.andDo(print());
 	}
 
-
-	// @Test
-	// void testTestMvc2() throws Exception {
-	// 	mockMvc.perform(MockMvcRequestBuilders.get("/test?str=user")
-	// 			.contentType(MediaType.APPLICATION_JSON)
-	// 		)
-	// 		.andExpect(status().is4xxClientError())
-	// 		.andExpect(jsonPath("$.status", notNullValue()))
-	// 		.andExpect(jsonPath("$.description", notNullValue()))
-	// 		.andDo(print());
-	// }
-	//
-	// @Test
-	// void testTestMvc3() throws Exception {
-	// 	mockMvc.perform(MockMvcRequestBuilders.get("/test?str=error")
-	// 			.contentType(MediaType.APPLICATION_JSON)
-	// 		)
-	// 		.andExpect(status().is5xxServerError())
-	// 		.andExpect(jsonPath("$.status", notNullValue()))
-	// 		.andExpect(jsonPath("$.description", notNullValue()))
-	// 		.andDo(print());
-	// }
-
 }

--- a/backend/src/test/java/com/project/Tamago/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/project/Tamago/controller/AuthControllerTest.java
@@ -17,7 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.project.Tamago.dto.JoinReqDto;
+import com.project.Tamago.dto.requestDto.JoinReqDto;
 import com.project.Tamago.exception.CustomException;
 import com.project.Tamago.jwt.JwtTokenProvider;
 import com.project.Tamago.repository.UserRepository;

--- a/backend/src/test/java/com/project/Tamago/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/project/Tamago/controller/UserControllerTest.java
@@ -1,11 +1,8 @@
 package com.project.Tamago.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,28 +11,20 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.project.Tamago.domain.User;
-import com.project.Tamago.dto.requestDto.ModifyProfileReqDto;
 import com.project.Tamago.dto.responseDto.ProfileResDto;
-import com.project.Tamago.jwt.JwtTokenProvider;
-import com.project.Tamago.repository.UserRepository;
 import com.project.Tamago.service.UserService;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 public class UserControllerTest {
 
-	@Autowired
-	private UserService userService;
 	@MockBean
-	private UserRepository userRepository;
-	@MockBean
-	private JwtTokenProvider jwtTokenProvider;
+	private UserService mockUserService;
 	@Autowired
 	private MockMvc mockMvc;
 
@@ -52,7 +41,7 @@ public class UserControllerTest {
 			.nickname("test")
 			.password("1234")
 			.build();
-		doReturn(new ProfileResDto(user)).when(userService).findProfileByJwtToken("test");
+		doReturn(new ProfileResDto(user)).when(mockUserService).findProfileByJwtToken("test");
 		// when
 		ResultActions resultActions = mockMvc.perform(get("/user/profile")
 			.contentType(MediaType.APPLICATION_JSON)
@@ -62,27 +51,4 @@ public class UserControllerTest {
 		resultActions.andExpect(status().isOk());
 	}
 
-	@Test
-	@DisplayName("유저 정보 변경하기")
-	@WithMockUser(username = "test", authorities = {"ROLE_USER"})
-	public void modifyUserProfile() throws Exception {
-		// given
-		User user = User.builder()
-			.id(1)
-			.email("test@naver.com")
-			.nickname("test")
-			.password("1234")
-			.build();
-
-		when(userRepository.findByNickname(any())).thenReturn(Optional.of(user));
-		when(jwtTokenProvider.getAuthentication(anyString())).thenReturn(new UsernamePasswordAuthenticationToken(new Object(), new Object()));
-
-		ModifyProfileReqDto modifyProfileReqDto = new ModifyProfileReqDto("안녕하세요",
-			"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT55B_AMMO9_gDppDBojupeVFHeQIg4zXSRDJ5COw4h&s");
-		// when
-		userService.modifyUserByJwtToken("any", modifyProfileReqDto);
-
-		// then
-		assertEquals(user.getIntroduce(), "안녕하세요");
-	}
 }

--- a/backend/src/test/java/com/project/Tamago/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/project/Tamago/controller/UserControllerTest.java
@@ -1,0 +1,52 @@
+package com.project.Tamago.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.project.Tamago.domain.User;
+import com.project.Tamago.dto.responseDto.ProfileResDto;
+import com.project.Tamago.service.UserService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class UserControllerTest {
+
+	@MockBean
+	private UserService userService;
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("유저 정보 가져오기 성공")
+	@WithMockUser(username = "user", authorities = {"ROLE_USER"})
+	public void join() throws Exception {
+		// given
+		User user = User.builder()
+			.id(1)
+			.email("test@naver.com")
+			.nickname("test")
+			.password("1234")
+			.build();
+		doReturn(new ProfileResDto(user)).when(userService).findProfileByJwtToken("test");
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/user/profile")
+			.contentType(MediaType.APPLICATION_JSON)
+			.header("Authorization", "test")
+		);
+		// then
+		resultActions.andExpect(status().isOk());
+	}
+
+}

--- a/backend/src/test/java/com/project/Tamago/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/project/Tamago/controller/UserControllerTest.java
@@ -1,8 +1,11 @@
 package com.project.Tamago.controller;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,12 +14,15 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.project.Tamago.domain.User;
+import com.project.Tamago.dto.requestDto.ModifyProfileReqDto;
 import com.project.Tamago.dto.responseDto.ProfileResDto;
+import com.project.Tamago.jwt.JwtTokenProvider;
 import com.project.Tamago.repository.UserRepository;
 import com.project.Tamago.service.UserService;
 
@@ -24,12 +30,16 @@ import com.project.Tamago.service.UserService;
 @AutoConfigureMockMvc
 public class UserControllerTest {
 
-	@MockBean
+	@Autowired
 	private UserService userService;
 	@MockBean
 	private UserRepository userRepository;
+	@MockBean
+	private JwtTokenProvider jwtTokenProvider;
 	@Autowired
 	private MockMvc mockMvc;
+
+
 
 	@Test
 	@DisplayName("유저 정보 가져오기 성공")
@@ -52,27 +62,27 @@ public class UserControllerTest {
 		resultActions.andExpect(status().isOk());
 	}
 
-	// @Test
-	// @DisplayName("유저 정보 변경하기")
-	// public void modifyUserProfile() throws Exception {
-	// 	// given
-	// 	User user = User.builder()
-	// 		.id(1)
-	// 		.email("test@naver.com")
-	// 		.nickname("test")
-	// 		.password("1234")
-	// 		.build();
-	// 	userRepository.save(user);
-	// 	Optional<User> optionalUser = Optional.of(user);
-	// 	doReturn(optionalUser).when(userRepository).findByNickname(anyString());
-	//
-	//
-	// 	ModifyProfileReqDto modifyProfileReqDto = new ModifyProfileReqDto("안녕하세요.",
-	// 		"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT55B_AMMO9_gDppDBojupeVFHeQIg4zXSRDJ5COw4h&s");
-	// 	// when
-	// 	userService.modifyUserByJwtToken("any", modifyProfileReqDto);
-	// 	// then
-	//
-	// 	System.out.println("user = " + user.getProfileImg());
-	// }
+	@Test
+	@DisplayName("유저 정보 변경하기")
+	@WithMockUser(username = "test", authorities = {"ROLE_USER"})
+	public void modifyUserProfile() throws Exception {
+		// given
+		User user = User.builder()
+			.id(1)
+			.email("test@naver.com")
+			.nickname("test")
+			.password("1234")
+			.build();
+
+		when(userRepository.findByNickname(any())).thenReturn(Optional.of(user));
+		when(jwtTokenProvider.getAuthentication(anyString())).thenReturn(new UsernamePasswordAuthenticationToken(new Object(), new Object()));
+
+		ModifyProfileReqDto modifyProfileReqDto = new ModifyProfileReqDto("안녕하세요",
+			"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT55B_AMMO9_gDppDBojupeVFHeQIg4zXSRDJ5COw4h&s");
+		// when
+		userService.modifyUserByJwtToken("any", modifyProfileReqDto);
+
+		// then
+		assertEquals(user.getIntroduce(), "안녕하세요");
+	}
 }

--- a/backend/src/test/java/com/project/Tamago/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/project/Tamago/controller/UserControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import com.project.Tamago.domain.User;
 import com.project.Tamago.dto.responseDto.ProfileResDto;
+import com.project.Tamago.repository.UserRepository;
 import com.project.Tamago.service.UserService;
 
 @SpringBootTest
@@ -25,13 +26,15 @@ public class UserControllerTest {
 
 	@MockBean
 	private UserService userService;
+	@MockBean
+	private UserRepository userRepository;
 	@Autowired
 	private MockMvc mockMvc;
 
 	@Test
 	@DisplayName("유저 정보 가져오기 성공")
 	@WithMockUser(username = "user", authorities = {"ROLE_USER"})
-	public void join() throws Exception {
+	public void findProfile() throws Exception {
 		// given
 		User user = User.builder()
 			.id(1)
@@ -49,4 +52,27 @@ public class UserControllerTest {
 		resultActions.andExpect(status().isOk());
 	}
 
+	// @Test
+	// @DisplayName("유저 정보 변경하기")
+	// public void modifyUserProfile() throws Exception {
+	// 	// given
+	// 	User user = User.builder()
+	// 		.id(1)
+	// 		.email("test@naver.com")
+	// 		.nickname("test")
+	// 		.password("1234")
+	// 		.build();
+	// 	userRepository.save(user);
+	// 	Optional<User> optionalUser = Optional.of(user);
+	// 	doReturn(optionalUser).when(userRepository).findByNickname(anyString());
+	//
+	//
+	// 	ModifyProfileReqDto modifyProfileReqDto = new ModifyProfileReqDto("안녕하세요.",
+	// 		"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT55B_AMMO9_gDppDBojupeVFHeQIg4zXSRDJ5COw4h&s");
+	// 	// when
+	// 	userService.modifyUserByJwtToken("any", modifyProfileReqDto);
+	// 	// then
+	//
+	// 	System.out.println("user = " + user.getProfileImg());
+	// }
 }

--- a/backend/src/test/java/com/project/Tamago/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/project/Tamago/controller/UserControllerTest.java
@@ -15,7 +15,9 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.Tamago.domain.User;
+import com.project.Tamago.dto.requestDto.ModifyProfileReqDto;
 import com.project.Tamago.dto.responseDto.ProfileResDto;
 import com.project.Tamago.service.UserService;
 
@@ -49,6 +51,23 @@ public class UserControllerTest {
 		);
 		// then
 		resultActions.andExpect(status().isOk());
+	}
+
+	@Test
+	@DisplayName("유저 정보 변경 실패 : introduce 길이 20 초과")
+	@WithMockUser(username = "user", authorities = {"ROLE_USER"})
+	public void modifyProfileWithIntroduceLength() throws Exception {
+		// given
+		ModifyProfileReqDto modifyProfileReqDto = new ModifyProfileReqDto(".............................................................",
+			"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT55B_AMMO9_gDppDBojupeVFHeQIg4zXSRDJ5COw4h&s");
+		// when
+		ResultActions resultActions = mockMvc.perform(patch("/user/profile")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(new ObjectMapper().writeValueAsString(modifyProfileReqDto))
+			.header("Authorization", "test")
+		);
+		// then
+		resultActions.andExpect(status().is4xxClientError());
 	}
 
 }

--- a/backend/src/test/java/com/project/Tamago/jwt/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/project/Tamago/jwt/JwtTokenProviderTest.java
@@ -10,7 +10,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.project.Tamago.dto.LoginReqDto;
+import com.project.Tamago.dto.requestDto.LoginReqDto;
 
 @SpringBootTest
 @Transactional

--- a/backend/src/test/java/com/project/Tamago/service/UserServiceTest.java
+++ b/backend/src/test/java/com/project/Tamago/service/UserServiceTest.java
@@ -1,0 +1,56 @@
+package com.project.Tamago.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import com.project.Tamago.domain.User;
+import com.project.Tamago.dto.requestDto.ModifyProfileReqDto;
+import com.project.Tamago.jwt.JwtTokenProvider;
+import com.project.Tamago.repository.UserRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class UserServiceTest {
+
+	@Autowired
+	private UserService userService;
+	@MockBean
+	private UserRepository userRepository;
+	@MockBean
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Test
+	@DisplayName("유저 정보 변경하기 성공")
+	@WithMockUser(username = "test", authorities = {"ROLE_USER"})
+	public void modifyUserProfile() {
+		// given
+		User user = User.builder()
+			.id(1)
+			.email("test@naver.com")
+			.nickname("test")
+			.password("1234")
+			.build();
+
+		when(userRepository.findByNickname(any())).thenReturn(Optional.of(user));
+		when(jwtTokenProvider.getAuthentication(anyString())).thenReturn(new UsernamePasswordAuthenticationToken(new Object(), new Object()));
+
+		ModifyProfileReqDto modifyProfileReqDto = new ModifyProfileReqDto("안녕하세요",
+			"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT55B_AMMO9_gDppDBojupeVFHeQIg4zXSRDJ5COw4h&s");
+		// when
+		userService.modifyUserByJwtToken("any", modifyProfileReqDto);
+
+		// then
+		assertEquals("안녕하세요", user.getIntroduce());
+	}
+}


### PR DESCRIPTION
## 📄 구현 내용 설명
- 프로필 조회 api 추가 (/users/profile) (GET)
- 프로필 수정 api 추가 (/users/profile) (PATCH)
- close #66 
### ⛱️ 주요 변경 사항
- 프로필 조회 api 추가 (/users/profile) (GET)
- 프로필 수정 api 추가 (/users/profile) (PATCH)
- h2 데이터베이스 사용가능
- 현재 MapStruct를 사용하지 않고 그냥 로직으로 구현했습니다
- refactoring이 많습니다. 디렉토리 변경을 많이 하였습니다

### 🙋 이 부분을 리뷰해주세요
- commit을 세분화 하였으니 커밋을 통해 PR리뷰를 보시는걸 추천드립니다.

### 🤔 여기를 참고하면 도움이 돼요

-   [하나도 안 중요한 iframe 안보셔도 됩니다.](https://yeoulcoding.me/143)
-  [@WithMockUser](https://gaemi606.tistory.com/entry/Spring-Boot-Spring-Security-Test-WithMockUser%EB%A5%BC-%EC%BB%A4%EC%8A%A4%ED%84%B0%EB%A7%88%EC%9D%B4%EC%A7%95-%ED%95%B4%EC%84%9C-%EC%82%AC%EC%9A%A9%ED%95%98%EC%9E%90)
