### PR TITLE
[#79] shell script를 통한 docker를 통한 서버 띄우기 자동화

### DIFF
--- a/dockerfile/backend-run-window.sh
+++ b/dockerfile/backend-run-window.sh
@@ -3,7 +3,7 @@ if [ -z $(docker ps -a -f "name=some-redis" -q) ]; then echo "null input-redis";
 else docker stop some-redis
 docker rm some-redis; fi
 sleep 1
-winpty docker run --name some-redis -d -p 6379:6379 redis
+docker run --name some-redis -d -p 6379:6379 redis
 
 sleep 1
 
@@ -12,4 +12,4 @@ if [ -z $(docker ps -a -f "name=release1" -q) ]; then echo "null input-tamago-lo
 else docker stop release1
 docker rm release1; fi
 sleep 1
-winpty docker run -d -p 8080:9000/tcp -i --name release1 baikjonghyun/tamago:lastest
+docker run -d -p 8080:9000/tcp -i --name release1 baikjonghyun/tamago:lastest


### PR DESCRIPTION
## 📄 구현 내용 설명
- shell script를 통한 docker를 통한 서버 띄우기 자동화
- window는 바로 실행이 되는 걸 확인했으나, Mac환경은 잘 모르겠음.
- backend-run.sh 만 실행하면 서버가 최신상태로 띄워집니다 이제!!
- close #79

### 🙋 이 부분을 리뷰해주세요
- Mac의 경우 : /dockerfile/backend-run.sh (테스트를 해보진 않았습니다.)
- 윈도우의 경우 : /dockerfile/backend-run-window.sh