### PR TITLE
[#88] 스토리북 배포 자동화 with github actions

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,21 +9,25 @@ on:
 
 # List of jobs
 jobs:
-  test:
+  chromatic-deployment:
     # Operating System
     runs-on: ubuntu-latest
-    # list of steps of actions
+    # Job steps
     steps:
-      - name: Check repository
       - uses: actions/checkout@v1
-        run: cd ./client
       - name: Install dependencies
-        run: yarn
-        #👇 Adds Chromatic as a step in the workflow
+        run: |
+          cd ./client
+          yarn
+
+      - name: Build storybook
+        run: |
+          cd ./client
+          yarn build-storybook
+
       - name: Publish to Chromatic
-      - uses: chromaui/action@v1
-        # Chromatic's GitHub Action options
+        uses: chromaui/action@v1
         with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          token: ${{ secrets.GITHUB_TOKEN }}
           workingDir: client
+          token: ${{ secrets.GITHUB_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/client/.storybook/main.js
+++ b/client/.storybook/main.js
@@ -1,4 +1,4 @@
-import path from 'path';
+const path = require('path');
 
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],

--- a/client/src/components/login/LoginForm/index.stories.tsx
+++ b/client/src/components/login/LoginForm/index.stories.tsx
@@ -9,7 +9,7 @@ export default {
   component: LoginForm,
 } as ComponentMeta<typeof LoginForm>;
 
-const Template: ComponentStory<typeof LoginForm> = (args) => {
+const Template: ComponentStory<typeof LoginForm> = () => {
   return (
     <ChakraProvider theme={theme}>
       <LoginForm />

--- a/client/src/components/login/LoginForm/index.tsx
+++ b/client/src/components/login/LoginForm/index.tsx
@@ -1,0 +1,3 @@
+export default function LoginForm() {
+  return <></>;
+}

--- a/client/src/utils/paths.ts
+++ b/client/src/utils/paths.ts
@@ -1,3 +1,1 @@
 export const INQUIRY_PW_PATH = '/password';
-
-export const Temp = 'sd1';


### PR DESCRIPTION
close #88 

## 📄 구현 내용 설명
Github actions를 통한 스토리북 CI/CD 설정이 완료되었습니다.

### ⛱️ 주요 변경 사항

- [.storybook > main.js](https://github.com/msdio/Tamago/blob/abe7bfcf2e8f8f748368c1a3ad333e1c79e0c8cc/client/.storybook/main.js#L1) 에서 module 밖에서 import 하는 코드가 있어 에러가 발생해, `require`로 변경했습니다.
- components > login > LoginForm에 스토리는 있는데 index 파일이 없어 에러가 발생했습니다. 해당 폴더 내에 index.tsx 파일을 생성해놓았습니다.
- 또한 위의 스토리 파일에 parameter가 필요 없는데도 arguments를 전달하고 있어 삭제했습니다.

### 🙋 이 부분을 리뷰해주세요

-
-

### 🤔 여기를 참고하면 도움이 돼요

-   [Automate Chromatic with GitHub Actions](https://www.chromatic.com/docs/github-actions)
-
