### PR TITLE
[#104] 긴글 세부조회 구현

### DIFF
--- a/backend/src/main/generated/com/project/Tamago/dto/mapper/DataMapperImpl.java
+++ b/backend/src/main/generated/com/project/Tamago/dto/mapper/DataMapperImpl.java
@@ -6,7 +6,10 @@ import com.project.Tamago.domain.Typing;
 import com.project.Tamago.domain.TypingHistory;
 import com.project.Tamago.domain.TypingHistory.TypingHistoryBuilder;
 import com.project.Tamago.domain.User;
+import com.project.Tamago.dto.PageContentDto;
 import com.project.Tamago.dto.requestDto.TypingHistoryReqDto;
+import com.project.Tamago.dto.responseDto.LongTypingDetailResDto;
+import com.project.Tamago.dto.responseDto.LongTypingDetailResDto.LongTypingDetailResDtoBuilder;
 import com.project.Tamago.dto.responseDto.LongTypingResDto;
 import com.project.Tamago.dto.responseDto.LongTypingResDto.LongTypingResDtoBuilder;
 import javax.annotation.processing.Generated;
@@ -14,7 +17,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2023-03-06T01:13:59+0900",
+    date = "2023-03-08T01:47:04+0900",
     comments = "version: 1.4.2.Final, compiler: javac, environment: Java 11.0.17 (Eclipse Adoptium)"
 )
 @Component
@@ -39,6 +42,28 @@ public class DataMapperImpl implements DataMapper {
         longTypingResDto.language( longTyping.getLanguage().toString() );
 
         return longTypingResDto.build();
+    }
+
+    @Override
+    public LongTypingDetailResDto LongTypingToLongTypingDetailResDto(LongTyping longTyping, PageContentDto pageContentDto) {
+        if ( longTyping == null && pageContentDto == null ) {
+            return null;
+        }
+
+        LongTypingDetailResDtoBuilder longTypingDetailResDto = LongTypingDetailResDto.builder();
+
+        if ( longTyping != null ) {
+            longTypingDetailResDto.typingId( longTyping.getId() );
+            longTypingDetailResDto.title( longTyping.getTitle() );
+            longTypingDetailResDto.totalPage( longTyping.getTotalPage() );
+        }
+        if ( pageContentDto != null ) {
+            longTypingDetailResDto.content( pageContentDto.getContent() );
+            longTypingDetailResDto.currentPage( pageContentDto.getPage() );
+        }
+        longTypingDetailResDto.language( longTyping.getLanguage().toString() );
+
+        return longTypingDetailResDto.build();
     }
 
     @Override

--- a/backend/src/main/generated/com/project/Tamago/dto/mapper/DataMapperImpl.java
+++ b/backend/src/main/generated/com/project/Tamago/dto/mapper/DataMapperImpl.java
@@ -17,8 +17,8 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2023-03-08T01:47:04+0900",
-    comments = "version: 1.4.2.Final, compiler: javac, environment: Java 11.0.17 (Eclipse Adoptium)"
+    date = "2023-03-09T06:33:15+0900",
+    comments = "version: 1.4.2.Final, compiler: javac, environment: Java 11.0.16 (Eclipse Adoptium)"
 )
 @Component
 public class DataMapperImpl implements DataMapper {

--- a/backend/src/main/generated/com/project/Tamago/dto/mapper/DataMapperImpl.java
+++ b/backend/src/main/generated/com/project/Tamago/dto/mapper/DataMapperImpl.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2023-03-09T06:33:15+0900",
+    date = "2023-03-09T23:31:45+0900",
     comments = "version: 1.4.2.Final, compiler: javac, environment: Java 11.0.16 (Eclipse Adoptium)"
 )
 @Component

--- a/backend/src/main/java/com/project/Tamago/constants/enums/Role.java
+++ b/backend/src/main/java/com/project/Tamago/constants/enums/Role.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 public enum Role {
 
-	USER("유저", "ROLE_USER"), ADMIN("관리자", "ROLE_ADMIN");
+	USER("USER", "ROLE_USER"), ADMIN("ADMIN", "ROLE_ADMIN");
 
 	private final String desc;
 	private final String type;

--- a/backend/src/main/java/com/project/Tamago/controller/TypingController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TypingController.java
@@ -3,12 +3,15 @@ package com.project.Tamago.controller;
 import java.util.List;
 import java.util.stream.Stream;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.project.Tamago.dto.CustomResponse;
+import com.project.Tamago.dto.responseDto.LongTypingDetailResDto;
 import com.project.Tamago.dto.responseDto.LongTypingResDto;
 import com.project.Tamago.dto.responseDto.ShortTypingListResDto;
 import com.project.Tamago.exception.CustomException;
@@ -17,7 +20,9 @@ import com.project.Tamago.service.LongTypingService;
 import com.project.Tamago.service.ShortTypingService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/typing")
@@ -40,4 +45,11 @@ public class TypingController {
 		return new CustomResponse<>(longTypingService.findLongTypings());
 	}
 
+	@GetMapping("/long/detail")
+	public CustomResponse<LongTypingDetailResDto> findLongTyping(HttpServletRequest request,
+		@RequestParam(required = true) Integer typingId,
+		@RequestParam(required = false) Integer page) {
+		String nickname = request.getHeader("nickname");
+		return new CustomResponse<>(longTypingService.findLongTyping(nickname, typingId, page));
+	}
 }

--- a/backend/src/main/java/com/project/Tamago/controller/TypingController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TypingController.java
@@ -46,7 +46,7 @@ public class TypingController {
 	}
 
 	@GetMapping("/long/detail")
-	public CustomResponse<LongTypingDetailResDto> findLongTyping(@RequestParam(required = true) Integer longTypingId,
+	public CustomResponse<LongTypingDetailResDto> findLongTyping(@RequestParam Integer longTypingId,
 		@RequestParam(required = false) Integer page) {
 		return new CustomResponse<>(longTypingService.findLongTyping(longTypingId, page));
 	}

--- a/backend/src/main/java/com/project/Tamago/controller/TypingController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TypingController.java
@@ -46,10 +46,8 @@ public class TypingController {
 	}
 
 	@GetMapping("/long/detail")
-	public CustomResponse<LongTypingDetailResDto> findLongTyping(HttpServletRequest request,
-		@RequestParam(required = true) Integer typingId,
+	public CustomResponse<LongTypingDetailResDto> findLongTyping(@RequestParam(required = true) Integer longTypingId,
 		@RequestParam(required = false) Integer page) {
-		String nickname = request.getHeader("nickname");
-		return new CustomResponse<>(longTypingService.findLongTyping(nickname, typingId, page));
+		return new CustomResponse<>(longTypingService.findLongTyping(longTypingId, page));
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/controller/TypingController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TypingController.java
@@ -47,7 +47,7 @@ public class TypingController {
 
 	@GetMapping("/long/detail")
 	public CustomResponse<LongTypingDetailResDto> findLongTyping(@RequestParam Integer longTypingId,
-		@RequestParam(required = false) Integer page) {
+		@RequestParam(required = false, defaultValue = "1") int page) {
 		return new CustomResponse<>(longTypingService.findLongTyping(longTypingId, page));
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/controller/UserController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/UserController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.project.Tamago.dto.CustomResponse;
@@ -37,5 +38,11 @@ public class UserController {
 		}
 		userService.modifyUserByJwtToken(jwtToken, modifyProfileReqDto);
 		return new CustomResponse<>();
+	}
+
+	@GetMapping("/typing/page")
+	public CustomResponse<Integer> findCurrentPage(@RequestHeader("Authorization") String jwtToken,
+		@RequestParam(required = true) Integer longTypingId) {
+		return new CustomResponse<>(userService.findCurrentPage(jwtToken, longTypingId));
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/domain/PagePosition.java
+++ b/backend/src/main/java/com/project/Tamago/domain/PagePosition.java
@@ -1,0 +1,36 @@
+package com.project.Tamago.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PagePosition {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "long_typing_id")
+	private LongTyping longTyping;
+
+	private Integer currentPage;
+}

--- a/backend/src/main/java/com/project/Tamago/dto/PageContentDto.java
+++ b/backend/src/main/java/com/project/Tamago/dto/PageContentDto.java
@@ -1,0 +1,11 @@
+package com.project.Tamago.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class PageContentDto {
+	private Integer page;
+	private String content;
+}

--- a/backend/src/main/java/com/project/Tamago/dto/mapper/DataMapper.java
+++ b/backend/src/main/java/com/project/Tamago/dto/mapper/DataMapper.java
@@ -8,7 +8,9 @@ import com.project.Tamago.domain.LongTyping;
 import com.project.Tamago.domain.Typing;
 import com.project.Tamago.domain.TypingHistory;
 import com.project.Tamago.domain.User;
+import com.project.Tamago.dto.PageContentDto;
 import com.project.Tamago.dto.requestDto.TypingHistoryReqDto;
+import com.project.Tamago.dto.responseDto.LongTypingDetailResDto;
 import com.project.Tamago.dto.responseDto.LongTypingResDto;
 
 @Mapper(componentModel = "spring")
@@ -19,6 +21,12 @@ public interface DataMapper {
 	@Mapping(source = "id", target = "typingId")
 	@Mapping(target = "language", expression = "java(longTyping.getLanguage().toString())")
 	LongTypingResDto LongTypingToLongTypingResDto(LongTyping longTyping);
+
+	@Mapping(source = "longTyping.id", target = "typingId")
+	@Mapping(target = "language", expression = "java(longTyping.getLanguage().toString())")
+	@Mapping(source = "pageContentDto.content", target = "content")
+	@Mapping(source = "pageContentDto.page", target = "currentPage")
+	LongTypingDetailResDto LongTypingToLongTypingDetailResDto(LongTyping longTyping, PageContentDto pageContentDto);
 
 	@Mapping(target = "id", ignore = true)
 	@Mapping(source = "typing", target = "typing")

--- a/backend/src/main/java/com/project/Tamago/dto/responseDto/LongTypingDetailResDto.java
+++ b/backend/src/main/java/com/project/Tamago/dto/responseDto/LongTypingDetailResDto.java
@@ -1,0 +1,15 @@
+package com.project.Tamago.dto.responseDto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class LongTypingDetailResDto {
+	private Integer typingId;
+	private String title;
+	private String content;
+	private String language;
+	private Integer currentPage;
+	private Integer totalPage;
+}

--- a/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ErrorCode.java
+++ b/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
 	USERS_INFO_NOT_EXISTS(3003, "유저 정보가 존재하지 않습니다."),
 	TYPING_INFO_NOT_EXISTS(3004, "존재하지 않는 글입니다."),
 	LONG_TYPING_INFO_NOT_EXISTS(4001, "해당 긴 글이 존재하지 않습니다."),
+	CURRENT_PAGE_NOT_EXISTS(4002, "연습한 페이지가 없습니다"),
 	;
 
 	private final int code;

--- a/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ErrorCode.java
+++ b/backend/src/main/java/com/project/Tamago/exception/exceptionHandler/ErrorCode.java
@@ -19,8 +19,8 @@ public enum ErrorCode {
 	USERS_EXISTS_EMAIL(3001, "중복된 이메일입니다."),
 	USERS_EXISTS_NICKNAME(3002, "중복된 닉네임입니다."),
 	USERS_INFO_NOT_EXISTS(3003, "유저 정보가 존재하지 않습니다."),
-
 	TYPING_INFO_NOT_EXISTS(3004, "존재하지 않는 글입니다."),
+	LONG_TYPING_INFO_NOT_EXISTS(4001, "해당 긴 글이 존재하지 않습니다."),
 	;
 
 	private final int code;

--- a/backend/src/main/java/com/project/Tamago/repository/LongTypingRepository.java
+++ b/backend/src/main/java/com/project/Tamago/repository/LongTypingRepository.java
@@ -1,5 +1,7 @@
 package com.project.Tamago.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,5 @@ import com.project.Tamago.domain.LongTyping;
 
 @Repository
 public interface LongTypingRepository extends JpaRepository<LongTyping, Integer> {
+	Optional<LongTyping> findByIdAndTotalPageGreaterThanEqual(Integer typingId, Integer page);
 }

--- a/backend/src/main/java/com/project/Tamago/repository/PagePositionRepository.java
+++ b/backend/src/main/java/com/project/Tamago/repository/PagePositionRepository.java
@@ -1,10 +1,17 @@
 package com.project.Tamago.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.project.Tamago.domain.PagePosition;
+import com.project.Tamago.domain.User;
 
 @Repository
 public interface PagePositionRepository extends JpaRepository<PagePosition, Integer> {
+	@Query("select p.currentPage from PagePosition p where p.user = :user and p.longTyping.id = :longTypingId")
+	Optional<Integer> findCurrentPageByUserAndTypingId(@Param("user") User user, @Param("longTypingId") Integer longTypingId);
 }

--- a/backend/src/main/java/com/project/Tamago/repository/PagePositionRepository.java
+++ b/backend/src/main/java/com/project/Tamago/repository/PagePositionRepository.java
@@ -1,0 +1,10 @@
+package com.project.Tamago.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.project.Tamago.domain.PagePosition;
+
+@Repository
+public interface PagePositionRepository extends JpaRepository<PagePosition, Integer> {
+}

--- a/backend/src/main/java/com/project/Tamago/repository/UserRepository.java
+++ b/backend/src/main/java/com/project/Tamago/repository/UserRepository.java
@@ -3,9 +3,11 @@ package com.project.Tamago.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import com.project.Tamago.domain.User;
 
+@Repository
 public interface UserRepository extends JpaRepository<User, Integer> {
 	Optional<User> findByEmailAndProvider(String email, String provider);
 

--- a/backend/src/main/java/com/project/Tamago/security/jwt/handler/CustomAuthenticationEntryPointHandler.java
+++ b/backend/src/main/java/com/project/Tamago/security/jwt/handler/CustomAuthenticationEntryPointHandler.java
@@ -15,7 +15,7 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import com.project.Tamago.exception.exceptionHandler.ErrorCode;
 
 public class CustomAuthenticationEntryPointHandler implements AuthenticationEntryPoint {
-	private final ErrorCode[] errorCodes = {EMPTY_JWT, EXPIRED_JWT, INVALID_JWT};
+	private final ErrorCode[] errorCodes = {EMPTY_JWT, EXPIRED_JWT, INVALID_JWT, INVALID_SIGNATURE};
 
 	@Override
 	public void commence(HttpServletRequest request, HttpServletResponse response,

--- a/backend/src/main/java/com/project/Tamago/service/LongTypingService.java
+++ b/backend/src/main/java/com/project/Tamago/service/LongTypingService.java
@@ -43,13 +43,9 @@ public class LongTypingService {
 	}
 
 	@Transactional(readOnly = true)
-	public LongTypingDetailResDto findLongTyping(Integer longTypingId, Integer page) {
-		if (page == null) {
-			page = 1;
-		}
+	public LongTypingDetailResDto findLongTyping(Integer longTypingId, int page) {
 		LongTyping longTyping = longTypingRepository.findByIdAndTotalPageGreaterThanEqual(longTypingId, page)
 			.orElseThrow(() -> new CustomException(LONG_TYPING_INFO_NOT_EXISTS));
-		PageContentDto pageContentDto = getPageContent(longTyping.getContent(), page);
 		return DataMapper.INSTANCE.LongTypingToLongTypingDetailResDto(longTyping, getPageContent(longTyping.getContent(), page));
 	}
 

--- a/backend/src/main/java/com/project/Tamago/service/LongTypingService.java
+++ b/backend/src/main/java/com/project/Tamago/service/LongTypingService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import com.project.Tamago.domain.LongTyping;
+import com.project.Tamago.domain.PagePosition;
 import com.project.Tamago.domain.User;
 import com.project.Tamago.dto.PageContentDto;
 import com.project.Tamago.dto.mapper.DataMapper;
@@ -42,18 +43,14 @@ public class LongTypingService {
 	}
 
 	@Transactional(readOnly = true)
-	public LongTypingDetailResDto findLongTyping(String nickname, Integer typingId, Integer page) {
+	public LongTypingDetailResDto findLongTyping(Integer longTypingId, Integer page) {
 		if (page == null) {
 			page = 1;
-			if (StringUtils.hasText(nickname)) {
-				User user = userRepository.findByNickname(nickname)
-					.orElseThrow(() -> new CustomException(USERS_INFO_NOT_EXISTS));
-			}
 		}
-		LongTyping longTyping = longTypingRepository.findByIdAndTotalPageGreaterThanEqual(typingId, page)
+		LongTyping longTyping = longTypingRepository.findByIdAndTotalPageGreaterThanEqual(longTypingId, page)
 			.orElseThrow(() -> new CustomException(LONG_TYPING_INFO_NOT_EXISTS));
 		PageContentDto pageContentDto = getPageContent(longTyping.getContent(), page);
-		return DataMapper.INSTANCE.LongTypingToLongTypingDetailResDto(longTyping, pageContentDto);
+		return DataMapper.INSTANCE.LongTypingToLongTypingDetailResDto(longTyping, getPageContent(longTyping.getContent(), page));
 	}
 
 	private PageContentDto getPageContent(String content, Integer page) {

--- a/backend/src/main/java/com/project/Tamago/service/LongTypingService.java
+++ b/backend/src/main/java/com/project/Tamago/service/LongTypingService.java
@@ -1,14 +1,25 @@
 package com.project.Tamago.service;
 
+import static com.project.Tamago.exception.exceptionHandler.ErrorCode.*;
+
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
+import com.project.Tamago.domain.LongTyping;
+import com.project.Tamago.domain.User;
+import com.project.Tamago.dto.PageContentDto;
 import com.project.Tamago.dto.mapper.DataMapper;
+import com.project.Tamago.dto.responseDto.LongTypingDetailResDto;
 import com.project.Tamago.dto.responseDto.LongTypingResDto;
+import com.project.Tamago.exception.CustomException;
 import com.project.Tamago.repository.LongTypingRepository;
+import com.project.Tamago.repository.PagePositionRepository;
+import com.project.Tamago.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,12 +29,38 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Transactional
 public class LongTypingService {
+	private static final int LINES_PER_PAGE = 20;
+	private final UserRepository userRepository;
 	private final LongTypingRepository longTypingRepository;
+	private final PagePositionRepository pagePositionRepository;
 
 	@Transactional(readOnly = true)
 	public List<LongTypingResDto> findLongTypings() {
 		return longTypingRepository.findAll().stream()
 			.map(DataMapper.INSTANCE::LongTypingToLongTypingResDto)
 			.collect(Collectors.toList());
+	}
+
+	@Transactional(readOnly = true)
+	public LongTypingDetailResDto findLongTyping(String nickname, Integer typingId, Integer page) {
+		if (page == null) {
+			page = 1;
+			if (StringUtils.hasText(nickname)) {
+				User user = userRepository.findByNickname(nickname)
+					.orElseThrow(() -> new CustomException(USERS_INFO_NOT_EXISTS));
+			}
+		}
+		LongTyping longTyping = longTypingRepository.findByIdAndTotalPageGreaterThanEqual(typingId, page)
+			.orElseThrow(() -> new CustomException(LONG_TYPING_INFO_NOT_EXISTS));
+		PageContentDto pageContentDto = getPageContent(longTyping.getContent(), page);
+		return DataMapper.INSTANCE.LongTypingToLongTypingDetailResDto(longTyping, pageContentDto);
+	}
+
+	private PageContentDto getPageContent(String content, Integer page) {
+		String[] contentLines = content.split("\r\n");
+		int startIndex = (page - 1) * LINES_PER_PAGE;
+		int endIndex = Math.min(startIndex + LINES_PER_PAGE, contentLines.length);
+		String pageContent = String.join("\n", Arrays.copyOfRange(contentLines, startIndex, endIndex));
+		return new PageContentDto(page, pageContent);
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/service/UserService.java
+++ b/backend/src/main/java/com/project/Tamago/service/UserService.java
@@ -9,6 +9,7 @@ import com.project.Tamago.domain.User;
 import com.project.Tamago.dto.requestDto.ModifyProfileReqDto;
 import com.project.Tamago.dto.responseDto.ProfileResDto;
 import com.project.Tamago.exception.CustomException;
+import com.project.Tamago.repository.PagePositionRepository;
 import com.project.Tamago.security.jwt.JwtTokenProvider;
 import com.project.Tamago.dto.mapper.UserMapper;
 import com.project.Tamago.repository.UserRepository;
@@ -23,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 public class UserService {
 
 	private final UserRepository userRepository;
+	private final PagePositionRepository pagePositionRepository;
 	private final JwtTokenProvider jwtTokenProvider;
 
 	@Transactional(readOnly = true)
@@ -32,6 +34,12 @@ public class UserService {
 
 	public void modifyUserByJwtToken(String jwtToken, ModifyProfileReqDto modifyProfileReqDto) {
 		getUserByJwtToken(jwtToken).modifyUserInfo(modifyProfileReqDto);
+	}
+
+	@Transactional(readOnly = true)
+	public Integer findCurrentPage(String jwtToken, Integer longTypingId) {
+		return pagePositionRepository.findCurrentPageByUserAndTypingId(getUserByJwtToken(jwtToken), longTypingId)
+			.orElseThrow(() -> new CustomException(CURRENT_PAGE_NOT_EXISTS));
 	}
 
 	private User getUserByJwtToken(String jwtToken) {

--- a/backend/src/test/java/com/project/Tamago/service/LongTypingServiceTest.java
+++ b/backend/src/test/java/com/project/Tamago/service/LongTypingServiceTest.java
@@ -5,8 +5,10 @@ import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -15,7 +17,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 
 import com.project.Tamago.constants.enums.Language;
 import com.project.Tamago.domain.LongTyping;
+import com.project.Tamago.dto.PageContentDto;
 import com.project.Tamago.dto.mapper.DataMapper;
+import com.project.Tamago.dto.responseDto.LongTypingDetailResDto;
 import com.project.Tamago.dto.responseDto.LongTypingResDto;
 import com.project.Tamago.repository.LongTypingRepository;
 
@@ -28,7 +32,9 @@ class LongTypingServiceTest {
 	private LongTypingRepository longTypingRepository;
 
 	@Test
+	@DisplayName("긴글 목록 조회 테스트")
 	public void testFindLongTypings() {
+		// given
 		LongTyping longTyping1 = LongTyping.builder()
 			.id(1)
 			.title("Test title 1")
@@ -53,8 +59,85 @@ class LongTypingServiceTest {
 			.map(DataMapper.INSTANCE::LongTypingToLongTypingResDto)
 			.collect(Collectors.toList());
 
+		// when
 		List<LongTypingResDto> actualLongTypingResDtos = longTypingService.findLongTypings();
 
+		// then
 		assertEquals(expectedLongTypingResDtos, actualLongTypingResDtos);
+	}
+
+	@Test
+	@DisplayName("긴글 세부 조회 성공 테스트")
+	public void testFindLongTypingSuccess() {
+		// given
+		Integer longTypingId = 1;
+		Integer page = 2;
+		String content = "line 1\r\nline 2\r\nline 3\r\nline 4\r\nline 5\r\nline 6\r\nline 7\r\nline 8\r\nline 9\r\nline 10\r\nline 11\r\nline 12\r\nline 13\r\nline 14\r\nline 15\r\nline 16\r\nline 17\r\nline 18\r\nline 19\r\nline 20\r\nline 21\r\nline 22\r\nline 23\r\nline 24\r\nline 25\r\nline 26\r\nline 27\r\nline 28\r\nline 29\r\nline 30";
+		LongTyping longTyping = LongTyping.builder()
+			.id(longTypingId)
+			.title("Test title")
+			.thumbnail("test Thumbnail")
+			.content(content)
+			.language(Language.ENGLISH)
+			.totalPage(10)
+			.viewCount(100)
+			.build();
+
+		PageContentDto expectedPageContentDto = new PageContentDto(2, "line 21\nline 22\nline 23\nline 24\nline 25\nline 26\nline 27\nline 28\nline 29\nline 30");
+		when(longTypingRepository.findByIdAndTotalPageGreaterThanEqual(longTypingId, page)).thenReturn(Optional.of(longTyping));
+
+		// when
+		LongTypingDetailResDto actualLongTypingDetailResDto = longTypingService.findLongTyping(longTypingId, page);
+
+		// then
+		assertEquals(expectedPageContentDto.getContent(), actualLongTypingDetailResDto.getContent());
+		assertEquals(expectedPageContentDto.getPage(), actualLongTypingDetailResDto.getCurrentPage());
+	}
+
+	@Test
+	@DisplayName("긴글 세부 조회 실패 테스트")
+	public void testFindLongTypingFail() {
+		// given
+		Integer longTypingId = 1;
+		Integer page = 2;
+		String content = "line 1\r\nline 2\r\nline 3\r\nline 4\r\nline 5\r\nline 6\r\nline 7\r\nline 8\r\nline 9\r\nline 10\r\nline 11\r\nline 12\r\nline 13\r\nline 14\r\nline 15\r\nline 16\r\nline 17\r\nline 18\r\nline 19\r\nline 20\r\nline 21\r\nline 22\r\nline 23\r\nline 24\r\nline 25\r\nline 26\r\nline 27\r\nline 28\r\nline 29\r\nline 30";
+		LongTyping longTyping = LongTyping.builder()
+			.id(longTypingId)
+			.title("Test title")
+			.thumbnail("test Thumbnail")
+			.content(content)
+			.language(Language.ENGLISH)
+			.totalPage(10)
+			.viewCount(100)
+			.build();
+
+		PageContentDto expectedPageContentDto = new PageContentDto(1, "line 1\n"
+			+ "line 2\n"
+			+ "line 3\n"
+			+ "line 4\n"
+			+ "line 5\n"
+			+ "line 6\n"
+			+ "line 7\n"
+			+ "line 8\n"
+			+ "line 9\n"
+			+ "line 10\n"
+			+ "line 11\n"
+			+ "line 12\n"
+			+ "line 13\n"
+			+ "line 14\n"
+			+ "line 15\n"
+			+ "line 16\n"
+			+ "line 17\n"
+			+ "line 18\n"
+			+ "line 19\n"
+			+ "line 20");
+		when(longTypingRepository.findByIdAndTotalPageGreaterThanEqual(longTypingId, page)).thenReturn(Optional.of(longTyping));
+
+		// when
+		LongTypingDetailResDto actualLongTypingDetailResDto = longTypingService.findLongTyping(longTypingId, page);
+
+		// then
+		assertNotEquals(expectedPageContentDto.getContent(), actualLongTypingDetailResDto.getContent());
+		assertNotEquals(expectedPageContentDto.getPage(), actualLongTypingDetailResDto.getCurrentPage());
 	}
 }

--- a/etc/dataMaker/sample_long_typing._data.sql
+++ b/etc/dataMaker/sample_long_typing._data.sql
@@ -3,28 +3,32 @@ INSERT INTO long_typing (title, content, thumbnail, language, length, total_page
                          updated_date)
 VALUES ('애국가 1절', '동해물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라만세 무궁화 삼천리 화려강산 대한사람 대한으로 길이 보전하세',
         SUBSTRING(REPLACE(content, '\r', ''), 1, 50),
-        'KOREAN', CHAR_LENGTH(content), ceiling((LENGTH - CHAR_LENGTH(REPLACE(content, '\n', '')) + 1) / 20.0), 0,
+        'KOREAN', CHAR_LENGTH(REPLACE(content, '\r', '')),
+        ceiling((LENGTH - CHAR_LENGTH(REPLACE(content, '\r\n', '')) + 1) / 20.0), 0,
         now(), now());
 
 INSERT INTO long_typing (title, content, thumbnail, language, LENGTH, total_page, VIEW_COUNT, created_date,
                          updated_date)
 VALUES ('애국가 2절', '남산위에 저 소나무 철갑을 두른듯 바람서리 불변함은 우리기상 일세 무궁화 삼천리 화려강산 대한사람 대한으로 길이 보전하세',
         SUBSTRING(REPLACE(content, '\r', ''), 1, 50),
-        'KOREAN', CHAR_LENGTH(content), ceiling((LENGTH - CHAR_LENGTH(REPLACE(content, '\n', '')) + 1) / 20.0), 0,
+        'KOREAN', CHAR_LENGTH(REPLACE(content, '\r', '')),
+        ceiling((LENGTH - CHAR_LENGTH(REPLACE(content, '\r\n', '')) + 1) / 20.0), 0,
         now(), now());
 
 INSERT INTO long_typing (title, content, thumbnail, language, LENGTH, total_page, VIEW_COUNT, created_date,
                          updated_date)
 VALUES ('애국가 3절', '가을하늘 공활한데 높고 구름없이 밝은달은 우리가슴 일편단심일세 무궁화 삼천리 화려강산 대한사람 대한으로 길이 보전하세',
         SUBSTRING(REPLACE(content, '\r', ''), 1, 50),
-        'KOREAN', CHAR_LENGTH(content), ceiling((LENGTH - CHAR_LENGTH(REPLACE(content, '\n', '')) + 1) / 20.0), 0,
+        'KOREAN', CHAR_LENGTH(REPLACE(content, '\r', '')),
+        ceiling((LENGTH - CHAR_LENGTH(REPLACE(content, '\r\n', '')) + 1) / 20.0), 0,
         now(), now());
 
 INSERT INTO long_typing (title, content, thumbnail, language, LENGTH, total_page, VIEW_COUNT, created_date,
                          updated_date)
 VALUES ('애국가 4절', '이 기상과 이 맘으로 충성을 다하여 괴로우나 즐거우나 나라사랑하세 무궁화 삼천리 화려강산 대한사람 대한으로 길이 보전하세',
         SUBSTRING(REPLACE(content, '\r', ''), 1, 50),
-        'KOREAN', CHAR_LENGTH(content), ceiling((LENGTH - CHAR_LENGTH(REPLACE(content, '\n', '')) + 1) / 20.0), 0,
+        'KOREAN', CHAR_LENGTH(REPLACE(content, '\r', '')),
+        ceiling((LENGTH - CHAR_LENGTH(REPLACE(content, '\r\n', '')) + 1) / 20.0), 0,
         now(), now());
 
 INSERT INTO long_typing (title, content, thumbnail, language, LENGTH, total_page, VIEW_COUNT, created_date,
@@ -41,8 +45,9 @@ Like a Diamond in the sky.
 Twinkle, twinkle, little star,
 How I wonder what you are!
 Twinkle, twinkle, little star,
-How I wonder what you are!', SUBSTRING(REPLACE(content, '\r', ''), 1, 50), 'ENGLISH', CHAR_LENGTH(content),
-        ceiling((LENGTH - CHAR_LENGTH(REPLACE(content, '\n', '')) + 1) / 20.0), 0, now(), now());
+How I wonder what you are!', SUBSTRING(REPLACE(content, '\r', ''), 1, 50), 'ENGLISH',
+        CHAR_LENGTH(REPLACE(content, '\r', '')),
+        ceiling((LENGTH - CHAR_LENGTH(REPLACE(content, '\r\n', '')) + 1) / 20.0), 0, now(), now());
 
 INSERT INTO long_typing (title, content, thumbnail, language, LENGTH, total_page, VIEW_COUNT, created_date,
                          updated_date)
@@ -108,8 +113,8 @@ It takes time
 또 시간이 들겠지
 It takes time
 It takes time
-It takes time', SUBSTRING(REPLACE(content, '\r', ''), 1, 50), 'KOREAN', CHAR_LENGTH(content),
-        ceiling((LENGTH - CHAR_LENGTH(REPLACE(content, '\n', '')) + 1) / 20.0), 0, now(), now());
+It takes time', SUBSTRING(REPLACE(content, '\r', ''), 1, 50), 'KOREAN', CHAR_LENGTH(REPLACE(content, '\r', '')),
+        ceiling((LENGTH - CHAR_LENGTH(REPLACE(content, '\r\n', '')) + 1) / 20.0), 0, now(), now());
 
 INSERT INTO long_typing (title, content, thumbnail, language, LENGTH, total_page, VIEW_COUNT, created_date,
                          updated_date)
@@ -154,5 +159,6 @@ VALUES ('Stack', 'public class Stack {
         return top == data.length - 1;
     }
 }', SUBSTRING(REPLACE(content, '\r', ''), 1, 50),
-        'JAVA', CHAR_LENGTH(content), ceiling((LENGTH - CHAR_LENGTH(REPLACE(content, '\n', '')) + 1) / 20.0), 0, now(),
+        'JAVA', CHAR_LENGTH(REPLACE(content, '\r', '')),
+        ceiling((LENGTH - CHAR_LENGTH(REPLACE(content, '\r\n', '')) + 1) / 20.0), 0, now(),
         now());


### PR DESCRIPTION
## 📄 구현 내용 설명
- closes  #104 긴글 세부조회 기능 구현에 대한 pr 
### ⛱️ 주요 변경 사항

- 긴글 테이블 생성했습니다(longTyping)
- 유저가 해당 긴글을 현재 몇페이지까지 연습했는지에 대한 페이지 릴레이션 생성했습니다(pagePosition)
- 기존 role enum의 desc부분 한글로 유저,관리자였는데 USER,ADMIN을 바꿨습니다([securityConfig hasRole쉽게하려고](https://whitepro.tistory.com/494))
- userController, userService에 유저의 현재 연습한 페이지를 요청하는 api 구현(로그인한 유저가, 본인의 연습한 페이지를 요청하는거라 longtyping이아닌 userService에 구현) - 조회시 longTypingId의 경우 파라미터로 받을수있기에 jpql로 구현해 join줄였습니다
- 긴글 세부조회 api 구현했습니다
