### PR TITLE
회원가입 유효성 검증(이메일, 패스워드) 로직 추가

### DIFF
--- a/backend/src/main/java/com/project/Tamago/dto/requestDto/JoinReqDto.java
+++ b/backend/src/main/java/com/project/Tamago/dto/requestDto/JoinReqDto.java
@@ -1,5 +1,9 @@
 package com.project.Tamago.dto.requestDto;
 
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 import com.project.Tamago.domain.User;
@@ -16,7 +20,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class JoinReqDto {
 
+	@NotBlank
+	@Email(message = "이메일 형식을 지켜주세요.")
 	private String email;
+	@Pattern(regexp = "(?=.*[A-Za-z])(?=.*\\d).{8,12}", message = "패스워드 형식을 지켜주세요.")
 	private String password;
 	@Size(max = 10, message = "닉네임은 10자 이하입니다.")
 	private String nickname;

--- a/backend/src/test/java/com/project/Tamago/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/project/Tamago/controller/AuthControllerTest.java
@@ -45,7 +45,7 @@ public class AuthControllerTest {
 		// given
 		JoinReqDto joinReqDto = JoinReqDto.builder()
 			.email("existing_email@example.com")
-			.password("password")
+			.password("password12")
 			.nickname("nickname").build();
 		// when
 		ResultActions resultActions = mockMvc.perform(post("/auth/join")
@@ -61,7 +61,7 @@ public class AuthControllerTest {
 		// given
 		JoinReqDto joinReqDto = JoinReqDto.builder()
 			.email("existing_email@example.com")
-			.password("password")
+			.password("password12")
 			.nickname("nickname").build();
 
 		doThrow(new CustomException(USERS_EXISTS_EMAIL)).when(authService).join(joinReqDto);
@@ -80,7 +80,7 @@ public class AuthControllerTest {
 		// given
 		JoinReqDto joinReqDto = JoinReqDto.builder()
 			.email("existing_email@example.com")
-			.password("password")
+			.password("password12")
 			.nickname("nickname").build();
 		doThrow(new CustomException(USERS_EXISTS_NICKNAME)).when(authService).join(joinReqDto);
 		// when
@@ -90,6 +90,42 @@ public class AuthControllerTest {
 		// then
 		resultActions.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.code").value(USERS_EXISTS_NICKNAME.getCode()));
+	}
+
+	@Test
+	@DisplayName("회원가입 실패: 이메일 형식 오류")
+	public void joinWithInvalidEmail() throws Exception {
+		// given
+		JoinReqDto joinReqDto = JoinReqDto.builder()
+			.email("invalidEmail")
+			.password("validEmail23")
+			.nickname("nickname").build();
+		// when
+		ResultActions resultActions = mockMvc.perform(post("/auth/join")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(new ObjectMapper().writeValueAsString(joinReqDto)));
+		// then
+		resultActions.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value(INVALID_PARAMETER.getCode()))
+			.andExpect(jsonPath("$.errors").value("이메일 형식을 지켜주세요."));
+	}
+
+	@Test
+	@DisplayName("회원가입 실패: 비밀번호 형식 오류")
+	public void joinWithInvalidPassword() throws Exception {
+		// given
+		JoinReqDto joinReqDto = JoinReqDto.builder()
+			.email("test@gmail.com")
+			.password("invalidEmail")
+			.nickname("nickname").build();
+		// when
+		ResultActions resultActions = mockMvc.perform(post("/auth/join")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(new ObjectMapper().writeValueAsString(joinReqDto)));
+		// then
+		resultActions.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value(INVALID_PARAMETER.getCode()))
+			.andExpect(jsonPath("$.errors").value("패스워드 형식을 지켜주세요."));
 	}
 
 	@Test


### PR DESCRIPTION
## 📄 구현 내용 설명

### ⛱️ 주요 변경 사항

- 회원가입시 이메일, 비밀번호 형식을 서버에서도 검증합니다

### 🤔 여기를 참고하면 도움이 돼요

![image](https://user-images.githubusercontent.com/78777461/224741599-b3ff392b-f93e-4df2-bbae-efa7a4456423.png)
![image](https://user-images.githubusercontent.com/78777461/224741721-e2cdc073-422e-4f03-8610-508531a5c3c5.png)
