### PR TITLE
[#178] originalTyping, userTyping으로 네이밍 변경

### DIFF
--- a/client/src/apis/typing.ts
+++ b/client/src/apis/typing.ts
@@ -10,6 +10,7 @@ export interface ShortTypingType {
 export interface ShortTypingResultType {
   contentType: '0' | '1';
   typingsType: 'practice';
+  // TODO: backend와 상의하기 ->  originalTyping: string;
   typingWritings: ShortTypingType[];
 }
 

--- a/client/src/components/practice/short/CurrentTyping/index.tsx
+++ b/client/src/components/practice/short/CurrentTyping/index.tsx
@@ -3,39 +3,39 @@ import type { ChangeEvent, KeyboardEvent } from 'react';
 import { useEffect } from 'react';
 import { useState } from 'react';
 
-import OriginalWriting from '@/components/practice/short/OriginalWriting';
+import OriginalTyping from '@/components/practice/short/OriginalTyping';
 import { useShortTypingContext, useShortTypingHandlerContext } from '@/components/practice/short/shortTypingContext';
 import { checkAllInputTyping } from '@/components/practice/short/utils';
 
-export default function CurrentTyping({}) {
-  const { originalWriting } = useShortTypingContext();
+export default function CurrentTyping() {
+  const { originalTyping } = useShortTypingContext();
   const { onEndTyping, onBackspace, onTyping } = useShortTypingHandlerContext();
 
-  const [input, setInput] = useState('');
+  const [userTyping, setUserTyping] = useState('');
 
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => {
     const word = e.target.value;
-    setInput(word);
+    setUserTyping(word);
 
     // NOTE : backspace 누른 경우
-    if (input.length > word.length) {
+    if (userTyping.length > word.length) {
       return;
     }
 
     onTyping(word);
 
     //? NOTE: 마지막 글자까지 입력하면, 제출하고 다음 문장으로 넘어간다.
-    if (word.length === originalWriting.length) {
+    if (word.length === originalTyping.length) {
       const isLast = checkAllInputTyping({
-        typingWord: word[originalWriting.length - 1],
-        originalWord: originalWriting[originalWriting.length - 1],
+        typingWord: word[originalTyping.length - 1],
+        originalWord: originalTyping[originalTyping.length - 1],
       });
 
       if (isLast) {
         onEndTyping(word);
       }
     }
-    if (word.length > originalWriting.length) {
+    if (word.length > originalTyping.length) {
       onEndTyping(word);
     }
   };
@@ -44,7 +44,7 @@ export default function CurrentTyping({}) {
     //? NOTE: enter 누른 경우 -> submit
     if (e.key === 'Enter') {
       e.preventDefault();
-      onEndTyping(input);
+      onEndTyping(userTyping);
     }
 
     // TODO : backspace 누른 경우 -> 타수에 영향
@@ -54,10 +54,10 @@ export default function CurrentTyping({}) {
   };
 
   useEffect(() => {
-    setInput('');
-  }, [originalWriting]);
+    setUserTyping('');
+  }, [originalTyping]);
 
-  if (!originalWriting) return <></>;
+  if (!originalTyping) return <></>;
 
   return (
     <Box
@@ -74,14 +74,14 @@ export default function CurrentTyping({}) {
       p='30px 49px'
       bg='#FFF2BA'
     >
-      <OriginalWriting originalWriting={originalWriting} inputWriting={input} />
+      <OriginalTyping originalTyping={originalTyping} userTyping={userTyping} />
 
       <Input
         bg='#FFE98B'
         variant='flushed'
         placeholder=' '
         type='text'
-        value={input}
+        value={userTyping}
         onChange={handleInput}
         onKeyDown={handleKeyDown}
         w='100%'

--- a/client/src/components/practice/short/OriginalTyping/index.tsx
+++ b/client/src/components/practice/short/OriginalTyping/index.tsx
@@ -1,14 +1,14 @@
 import { Flex, Text } from '@chakra-ui/react';
 
-interface OriginalWritingProps {
-  originalWriting: string;
-  inputWriting: string;
+interface OriginalTypingProps {
+  originalTyping: string;
+  userTyping: string;
 }
 
-export default function OriginalWriting({ originalWriting, inputWriting }: OriginalWritingProps) {
+export default function OriginalTyping({ originalTyping, userTyping }: OriginalTypingProps) {
   return (
     <Flex pl='5px' mb='10px' fontSize='23px' fontWeight={500}>
-      {originalWriting.split('').map((word, idx) => {
+      {originalTyping.split('').map((word, idx) => {
         if (word === ' ') {
           return (
             <Text as='span' key={idx}>
@@ -16,7 +16,7 @@ export default function OriginalWriting({ originalWriting, inputWriting }: Origi
             </Text>
           );
         }
-        if (idx < inputWriting.length - 1 && word !== inputWriting[idx]) {
+        if (idx < userTyping.length - 1 && word !== userTyping[idx]) {
           return (
             <Text as='span' bg='red' color='#fff' key={idx}>
               {word}

--- a/client/src/components/practice/short/PrevTyping/index.tsx
+++ b/client/src/components/practice/short/PrevTyping/index.tsx
@@ -1,21 +1,21 @@
 import { Box, Text } from '@chakra-ui/react';
 
-import OriginalWriting from '@/components/practice/short/OriginalWriting';
+import OriginalTyping from '@/components/practice/short/OriginalTyping';
 import { useShortTypingContext } from '@/components/practice/short/shortTypingContext';
 
 function PrevTyping() {
-  const { prevWritingInput, prevWritingCorrect } = useShortTypingContext();
+  const { prevUserTyping, prevOriginalTyping } = useShortTypingContext();
 
   return (
     <Box m='26px 36px'>
       <Box p='11px 17px' borderRadius='10px' h='48px'>
         <Box color='#7B7B7B' fontSize={20}>
-          <OriginalWriting originalWriting={prevWritingCorrect} inputWriting={prevWritingInput} />
+          <OriginalTyping originalTyping={prevOriginalTyping} userTyping={prevUserTyping} />
         </Box>
       </Box>
       <Box p='11px 17px' bg='#F4F4F4' borderRadius='10px' h='48px'>
         <Text color='#7B7B7B' fontSize={20}>
-          {prevWritingInput}
+          {prevUserTyping}
         </Text>
       </Box>
     </Box>

--- a/client/src/components/practice/short/currentTypingContext.tsx
+++ b/client/src/components/practice/short/currentTypingContext.tsx
@@ -10,20 +10,20 @@ import { getTypingAccuracy, getTypingSpeed, getTypingWpm, getWrongKeys } from '@
 
 interface UseCurrentTypingReturns {
   time: number;
-  originalWriting: string;
+  originalTyping: string;
 
   typingCount: number;
   typingWpm: number;
   typingAccuracy: number;
 
   handleBackspace: () => void;
-  handleTyping: (input: string) => void;
-  handleTypingSubmit: (inputWriting: string) => Promise<void>;
+  handleTyping: (userTyping: string) => void;
+  handleTypingSubmit: (userTyping: string) => Promise<void>;
 }
 
 export default function useCurrentTyping({
   typingId,
-  content: originalWriting,
+  content: originalTyping,
 }: ShortTypingType): UseCurrentTypingReturns {
   const { time, status, timePlay, timeReset, totalMillisecond, startTime } = useStopwatch();
 
@@ -42,24 +42,24 @@ export default function useCurrentTyping({
   }, []);
 
   const handleTypingAccuracy = useCallback(
-    (inputWriting: string) => {
+    (userTyping: string) => {
       const wrongLength = getWrongLength({
-        originalWriting,
-        inputWriting: inputWriting.slice(0, inputWriting.length - 1),
+        originalTyping: originalTyping,
+        userTyping: userTyping.slice(0, userTyping.length - 1),
       });
 
       const newAccuracy = getTypingAccuracy({
-        typingLength: originalWriting.length,
+        typingLength: originalTyping.length,
         wrongLength,
       });
 
       setTypingAccuracy(parseInt(newAccuracy, 10));
     },
-    [originalWriting],
+    [originalTyping],
   );
 
   const handleTyping = useCallback(
-    (input: string) => {
+    (userTyping: string) => {
       // 경과 시간 계산 시작
       if (status !== 'play') {
         timePlay();
@@ -67,7 +67,7 @@ export default function useCurrentTyping({
 
       typingCount.current += 1; // 글쇠 1개당 1타
       // //? 타이핑 정확도 계산 - 오타 계산
-      handleTypingAccuracy(input);
+      handleTypingAccuracy(userTyping);
     },
     [handleTypingAccuracy, status, timePlay],
   );
@@ -84,7 +84,7 @@ export default function useCurrentTyping({
 
   const generateTypingInfo = useCallback(
     (resultContent: string) => {
-      const originalInfos = [...originalWriting].map((char) => ({
+      const originalInfos = [...originalTyping].map((char) => ({
         char,
         type: getCharType(char),
         components: disassemble(char),
@@ -110,7 +110,7 @@ export default function useCurrentTyping({
 
       return typingHistory;
     },
-    [originalWriting, startTime, typingAccuracy, typingId, typingSpeed, typingWpm],
+    [originalTyping, startTime, typingAccuracy, typingId, typingSpeed, typingWpm],
   );
 
   const handleSubmit = useCallback(
@@ -148,7 +148,7 @@ export default function useCurrentTyping({
 
   return {
     time: parseInt(String(totalMillisecond / 1000), 10),
-    originalWriting,
+    originalTyping,
     typingCount: typingCount.current,
     typingWpm,
     typingAccuracy,

--- a/client/src/components/practice/short/index.tsx
+++ b/client/src/components/practice/short/index.tsx
@@ -7,13 +7,13 @@ import { useShortTypingContext } from '@/components/practice/short/shortTypingCo
 import TwoRightArrow from '@/icons/TwoRightArrow';
 
 export default function PracticeShort() {
-  const { originalWriting, nextWritingContent } = useShortTypingContext();
+  const { originalTyping, nextOriginalTyping } = useShortTypingContext();
 
   return (
     <Box p='35px 120px' minW='1100px'>
       <InfoBar />
 
-      {originalWriting && (
+      {originalTyping && (
         <Box position='relative' border='0.6px solid #000000' borderRadius='30px 0px 0px 0px' mt='28px'>
           <PrevTyping />
 
@@ -22,7 +22,7 @@ export default function PracticeShort() {
           <Flex p='24px 40px 32px' alignItems='center' gap='16.18px'>
             <TwoRightArrow />
             <Text fontSize='20px' color='#3C3C3C'>
-              {nextWritingContent}
+              {nextOriginalTyping}
             </Text>
           </Flex>
         </Box>

--- a/client/src/components/practice/short/shortTypingContext.tsx
+++ b/client/src/components/practice/short/shortTypingContext.tsx
@@ -6,20 +6,19 @@ import useCurrentTyping from '@/components/practice/short/currentTypingContext';
 
 interface ShortTypingContextType {
   time: number;
-  originalWriting: string;
+  originalTyping: string;
 
   typingCount: number;
   typingWpm: number;
   typingAccuracy: number;
 
-  prevWritingInput: string;
-  prevWritingCorrect: string;
-  nextWritingContent: string;
+  prevUserTyping: string;
+  prevOriginalTyping: string;
+  nextOriginalTyping: string;
 }
 
 interface ShortTypingHandlerContextType {
   onEndTyping: (input: string) => Promise<void>;
-
   onBackspace: () => void;
   onTyping: (inputChar: string) => void;
 }
@@ -29,14 +28,14 @@ const ShortTypingHandlerContext = createContext<ShortTypingHandlerContextType | 
 
 interface ShortTypingProviderProps {
   children: ReactNode;
-  typingWritings: ShortTypingType[];
+  originalTypings: ShortTypingType[];
 }
 
-const ShortTypingProvider = ({ children, typingWritings }: ShortTypingProviderProps) => {
+const ShortTypingProvider = ({ children, originalTypings }: ShortTypingProviderProps) => {
   const [currentIdx, setCurrentIdx] = useState(0);
-  const prevWritingInput = useRef('');
+  const prevUserTyping = useRef('');
   const {
-    originalWriting,
+    originalTyping,
     time,
     typingCount,
     typingAccuracy,
@@ -45,24 +44,24 @@ const ShortTypingProvider = ({ children, typingWritings }: ShortTypingProviderPr
     handleTypingSubmit,
     handleTyping,
   } = useCurrentTyping(
-    typingWritings[currentIdx] ?? {
+    originalTypings[currentIdx] ?? {
       typingId: 0,
       content: '',
     },
   );
 
-  const prevWritingCorrect = useMemo(
-    () => (currentIdx > 0 ? typingWritings[currentIdx - 1]?.content : ''),
-    [currentIdx, typingWritings],
+  const prevOriginalTyping = useMemo(
+    () => (currentIdx > 0 ? originalTypings[currentIdx - 1]?.content : ''),
+    [currentIdx, originalTypings],
   );
 
-  const nextWritingContent = useMemo(
-    () => (currentIdx < typingWritings.length - 1 ? typingWritings[currentIdx + 1].content : ''),
-    [currentIdx, typingWritings],
+  const nextOriginalTyping = useMemo(
+    () => (currentIdx < originalTypings.length - 1 ? originalTypings[currentIdx + 1].content : ''),
+    [currentIdx, originalTypings],
   );
 
   const handleSubmit = async (input: string) => {
-    prevWritingInput.current = input;
+    prevUserTyping.current = input;
 
     handleTypingSubmit(input);
   };
@@ -70,7 +69,7 @@ const ShortTypingProvider = ({ children, typingWritings }: ShortTypingProviderPr
   const handleEndTyping = async (input: string) => {
     await handleSubmit(input);
 
-    if (currentIdx < typingWritings.length - 1) {
+    if (currentIdx < originalTypings.length - 1) {
       setCurrentIdx((prev) => prev + 1);
     } else {
       // TODO : 30문장 끝
@@ -82,10 +81,10 @@ const ShortTypingProvider = ({ children, typingWritings }: ShortTypingProviderPr
     typingCount: typingCount,
     typingWpm,
     typingAccuracy,
-    originalWriting,
-    prevWritingInput: prevWritingInput.current,
-    prevWritingCorrect,
-    nextWritingContent,
+    originalTyping,
+    prevUserTyping: prevUserTyping.current,
+    prevOriginalTyping,
+    nextOriginalTyping,
   };
 
   const actions = {

--- a/client/src/components/practice/short/utils.ts
+++ b/client/src/components/practice/short/utils.ts
@@ -1,15 +1,9 @@
 import { disassemble } from 'hangul-js';
 
-export const getWrongLength = ({
-  originalWriting,
-  inputWriting,
-}: {
-  originalWriting: string;
-  inputWriting: string;
-}) => {
+export const getWrongLength = ({ originalTyping, userTyping }: { originalTyping: string; userTyping: string }) => {
   let wrongCount = 0;
-  for (let i = 0; i < inputWriting.length; i++) {
-    if (inputWriting[i] !== originalWriting[i]) {
+  for (let i = 0; i < userTyping.length; i++) {
+    if (userTyping[i] !== originalTyping[i]) {
       wrongCount += 1;
     }
   }

--- a/client/src/pages/practice/short.tsx
+++ b/client/src/pages/practice/short.tsx
@@ -28,7 +28,7 @@ export default function PracticeShortPage() {
   if (!data) <>error</>;
 
   return (
-    <ShortTypingProvider typingWritings={data.typingWritings}>
+    <ShortTypingProvider originalTypings={data.typingWritings}>
       <PracticeShort />;
     </ShortTypingProvider>
   );


### PR DESCRIPTION
## 📄 구현 내용 설명
close #178 
짧은글 originalTyping, userTyping으로 네이밍 변경
### ⛱️ 주요 변경 사항

- originalWriting, input, inputWriting, typingWriting 등 같은 의미가 반복되는 부분을 통일
-

### 🙋 이 부분을 리뷰해주세요

- 백엔드에서 입력할 짧은 글 데이터를 줄때 typingWritings 라는 이름으로 주는 상태입니다. 통일을 위해 백엔드에도 수정을 요청하는 것이 좋을까요?