### PR TITLE
연습모드 결과 모달 수정

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,17 +1,18 @@
 {
-    "java.compile.nullAnalysis.mode": "disabled",
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "eslint.format.enable": true,
-    "editor.codeActionsOnSave": {
-        "source.fixAll.stylelint": true,
-        "source.fixAll.eslint": true
-    },
-    "eslint.alwaysShowStatus": true,
-    "eslint.validate": [
-        "javascript",
-        "javascriptreact",
-        "typescript",
-        "typescriptreact"
-    ],
-    "editor.tabSize": 2
+  "java.compile.nullAnalysis.mode": "disabled",
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "eslint.format.enable": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.stylelint": true,
+    "source.fixAll.eslint": true
+  },
+  "eslint.alwaysShowStatus": true,
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  "editor.tabSize": 2,
+  "cSpell.words": ["YYYYMMDDHHMM"]
 }

--- a/client/src/apis/typing.ts
+++ b/client/src/apis/typing.ts
@@ -67,8 +67,16 @@ export const getLongTypingAPI = async ({
   return res.data;
 };
 
-// TODO : 로그인을 하지않은 상태에서는 타이핑 기록 API를 호출하지 않는다?
 export const getTypingHistoryAPI = async (typingHistory: TypingHistoryRequest) => {
+  // NOTE : 로그인이 되어있는지 여부는 accessToken이 localStorage에 있는지 여부로 판단한다. vs recoil user 정보로 판단한다.
+  const accessToken = localStorage.getItem('accessToken');
+
+  // NOTE : 로그인을 하지않은 상태에서는 타이핑 기록 API를 호출하지 않는다
+  // TODO : 연습모드인 경우에만, 실전 모드에서는 로그인시 어떻게 할것인지 고민해보기
+  if (accessToken === null) {
+    return;
+  }
+
   const res = await requestWithAuth.post('/typing/history', typingHistory);
   return res.data.code;
 };

--- a/client/src/components/common/PrepareAlert/index.tsx
+++ b/client/src/components/common/PrepareAlert/index.tsx
@@ -1,0 +1,9 @@
+import Alert from '@/components/common/Alert';
+
+interface PrepareAlertProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+export default function PrepareAlert({ isOpen, onClose }: PrepareAlertProps) {
+  return <Alert header='준비중인 기능입니다.' isOpen={isOpen} onClose={onClose} />;
+}

--- a/client/src/components/common/ResultModal/InfoList/index.tsx
+++ b/client/src/components/common/ResultModal/InfoList/index.tsx
@@ -1,5 +1,5 @@
 import InfoItem from '@/components/common/ResultModal/InfoList/Item';
-import type { TypingResultType } from '@/components/common/ResultModal/types';
+import type { TypingResultType } from '@/types/typing';
 import { getSecondToMMSSFormat } from '@/utils/time';
 
 type InfoListProps = TypingResultType;

--- a/client/src/components/common/ResultModal/exam-mode.tsx
+++ b/client/src/components/common/ResultModal/exam-mode.tsx
@@ -13,92 +13,93 @@ import {
 import Link from 'next/link';
 
 import IconButton from '@/components/common/IconButton';
+import PrepareAlert from '@/components/common/PrepareAlert';
 import InfoList from '@/components/common/ResultModal/InfoList';
-import type { TypingResultType } from '@/components/common/ResultModal/types';
 import { Tier } from '@/components/common/Tier';
+import useToggle from '@/hooks/useToggle';
 import { BookmarkOff } from '@/icons/Heart';
-import Share from '@/icons/Share';
+import type { TypingResultType } from '@/types/typing';
 
 interface ResultModalProps {
   isOpen: boolean;
   onReplay: () => void;
 
-  tier: number; // TODO : modal 에서 tier을 계산할지 고민
+  tier: number;
   result: TypingResultType;
 }
 
 export default function ExamResultModal({ onReplay, isOpen, result }: ResultModalProps) {
-  const onBookmark = () => {
-    console.log('click Bookmark: ');
-  };
+  const [isPrepareModalOpen, togglePrepareModal] = useToggle();
 
-  const onShare = () => {
-    console.log('click Share: ', onShare);
+  const onBookmark = () => {
+    togglePrepareModal();
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={onReplay} size='2xl'>
-      <ModalOverlay />
-      <ModalContent m='auto' p='49px 58px 42px' width='636px'>
-        <ModalHeader p={0}>
-          <Flex justifyContent='space-between'>
-            <Text fontSize='30px' fontWeight={700}>
-              짧은 글 연습모드 결과
-            </Text>
-            <Flex gap='14px'>
-              <IconButton onAction={onShare} icon={<Share />} />
-              <IconButton onAction={onBookmark} icon={<BookmarkOff />} />
+    <>
+      <Modal isOpen={isOpen} onClose={onReplay} size='2xl'>
+        <ModalOverlay />
+        <ModalContent m='auto' p='49px 58px 42px' width='636px'>
+          <ModalHeader p={0}>
+            <Flex justifyContent='space-between'>
+              <Text fontSize='30px' fontWeight={700}>
+                짧은 글 연습모드 결과
+              </Text>
+              <Flex gap='14px'>
+                <IconButton onAction={onBookmark} icon={<BookmarkOff />} />
+              </Flex>
             </Flex>
-          </Flex>
-          <Text color='gray.dark' fontSize='14px' fontWeight={500}>
-            2023.03.20 13:23
-          </Text>
-        </ModalHeader>
+            <Text color='gray.dark' fontSize='14px' fontWeight={500}>
+              2023.03.20 13:23
+            </Text>
+          </ModalHeader>
 
-        <ModalBody mt='32px' mb='53px' p={0}>
-          <Flex gap='65px'>
-            {/* TODO : tier 마다 크기가 다름 */}
-            <Box w={190} fontFamily='GangwonEduPower' textAlign='center'>
-              <Box position='relative' w='190px'>
-                <Box zIndex={1} position='relative' w='180px' top='20px' m='auto'>
-                  <Tier level={5} />
+          <ModalBody mt='32px' mb='53px' p={0}>
+            <Flex gap='65px'>
+              {/* TODO : tier 마다 크기가 다름 */}
+              <Box w={190} fontFamily='GangwonEduPower' textAlign='center'>
+                <Box position='relative' w='190px'>
+                  <Box zIndex={1} position='relative' w='180px' top='20px' m='auto'>
+                    <Tier level={5} />
+                  </Box>
+                  <Box
+                    top={0}
+                    bg='background.main'
+                    borderRadius='50%'
+                    w='190px'
+                    h='190px'
+                    position='absolute'
+                    zIndex={0}
+                  />
                 </Box>
-                <Box
-                  top={0}
-                  bg='background.main'
-                  borderRadius='50%'
-                  w='190px'
-                  h='190px'
-                  position='absolute'
-                  zIndex={0}
-                />
+                <Text fontSize='20px' fontWeight={400} mt='20px'>
+                  Lv.5
+                </Text>
+                <Text fontSize='19px' fontWeight={600} mt='8px'>
+                  위풍당당한 닭
+                </Text>
               </Box>
-              <Text fontSize='20px' fontWeight={400} mt='20px'>
-                Lv.5
-              </Text>
-              <Text fontSize='19px' fontWeight={600} mt='8px'>
-                위풍당당한 닭
-              </Text>
-            </Box>
-            <Box w='264px'>
-              <Text fontSize='19px' fontWeight={600} color='black.dark' mb='14px'>
-                메밀꽃 필 무렵
-              </Text>
-              <InfoList {...result} />
-            </Box>
-          </Flex>
-        </ModalBody>
-        <ModalFooter justifyContent='center' p='0' gap='17px'>
-          <Button w='174px' onClick={onReplay}>
-            다시 하기
-          </Button>
-          <Link href='/'>
-            <Button w='174px' variant='outline'>
-              메인화면으로 가기
+              <Box w='264px'>
+                <Text fontSize='19px' fontWeight={600} color='black.dark' mb='14px'>
+                  메밀꽃 필 무렵
+                </Text>
+                <InfoList {...result} />
+              </Box>
+            </Flex>
+          </ModalBody>
+          <ModalFooter justifyContent='center' p='0' gap='17px'>
+            <Button w='174px' onClick={onReplay}>
+              다시 하기
             </Button>
-          </Link>
-        </ModalFooter>
-      </ModalContent>
-    </Modal>
+            <Link href='/'>
+              <Button w='174px' variant='outline'>
+                메인화면으로 가기
+              </Button>
+            </Link>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+      <PrepareAlert isOpen={isPrepareModalOpen} onClose={togglePrepareModal} />
+    </>
   );
 }

--- a/client/src/components/common/ResultModal/practice-mode.tsx
+++ b/client/src/components/common/ResultModal/practice-mode.tsx
@@ -13,19 +13,19 @@ import {
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
-import Alert from '@/components/common/Alert';
 import IconButton from '@/components/common/IconButton';
+import PrepareAlert from '@/components/common/PrepareAlert';
 import InfoList from '@/components/common/ResultModal/InfoList';
-import type { TypingResultType } from '@/components/common/ResultModal/types';
 import useToggle from '@/hooks/useToggle';
 import { BookmarkOff } from '@/icons/Heart';
+import type { TypingResultType } from '@/types/typing';
 import { getDateYYYYMMDDHHMMFormat } from '@/utils/time';
 
 interface ResultModalProps {
   isOpen: boolean;
   result: TypingResultType;
-  onClose: () => void;
   endTime: Date;
+  onClose: () => void;
 
   title?: string;
 }
@@ -57,7 +57,6 @@ export default function PracticeResultModal({ onClose, title, isOpen, result, en
                 {isLong ? '긴 글' : '짧은 글'} 연습모드 결과
               </Text>
               <Flex gap='14px'>
-                {/* <IconButton onAction={onShare} icon={<Share />} /> */}
                 <IconButton onAction={onBookmark} icon={<BookmarkOff />} />
               </Flex>
             </Flex>
@@ -74,14 +73,13 @@ export default function PracticeResultModal({ onClose, title, isOpen, result, en
                     {title}
                   </Text>
                 )}
-
                 <InfoList {...result} />
               </Box>
             </Flex>
           </ModalBody>
           <ModalFooter justifyContent='center' p='0' gap='17px'>
             <Button w='174px' onClick={onReplay}>
-              이어 하기
+              다시 하기
             </Button>
             <Link href='/'>
               <Button w='174px' variant='outline'>
@@ -91,7 +89,7 @@ export default function PracticeResultModal({ onClose, title, isOpen, result, en
           </ModalFooter>
         </ModalContent>
       </Modal>
-      <Alert header='준비중인 기능입니다.' isOpen={isPrepareModalOpen} onClose={togglePrepareModal} />
+      <PrepareAlert isOpen={isPrepareModalOpen} onClose={togglePrepareModal} />
     </>
   );
 }

--- a/client/src/components/common/ResultModal/practice-mode.tsx
+++ b/client/src/components/common/ResultModal/practice-mode.tsx
@@ -42,6 +42,7 @@ export default function PracticeResultModal({ onClose, title, isOpen, result, en
   };
 
   const onReplay = () => {
+    // NOTE : 다시하기 기능은 새로고침으로 구현했는데, 긴글에서도 새로고침으로 해도 괜찮을까요?
     onClose();
     router.reload();
   };

--- a/client/src/components/common/ResultModal/practice-mode.tsx
+++ b/client/src/components/common/ResultModal/practice-mode.tsx
@@ -11,7 +11,6 @@ import {
   Text,
 } from '@chakra-ui/react';
 import Link from 'next/link';
-import { useRouter } from 'next/router';
 
 import IconButton from '@/components/common/IconButton';
 import PrepareAlert from '@/components/common/PrepareAlert';
@@ -25,26 +24,18 @@ interface ResultModalProps {
   isOpen: boolean;
   result: TypingResultType;
   endTime: Date;
-  onClose: () => void;
+  onReplay: () => void;
 
   title?: string;
 }
 
-export default function PracticeResultModal({ onClose, title, isOpen, result, endTime }: ResultModalProps) {
-  const router = useRouter();
-
+export default function PracticeResultModal({ title, isOpen, result, endTime, onReplay }: ResultModalProps) {
   const [isPrepareModalOpen, togglePrepareModal] = useToggle();
 
   const isLong = !!title;
 
   const onBookmark = () => {
     togglePrepareModal();
-  };
-
-  const onReplay = () => {
-    // NOTE : 다시하기 기능은 새로고침으로 구현했는데, 긴글에서도 새로고침으로 해도 괜찮을까요?
-    onClose();
-    router.reload();
   };
 
   return (

--- a/client/src/components/common/ResultModal/practice-mode.tsx
+++ b/client/src/components/common/ResultModal/practice-mode.tsx
@@ -18,17 +18,20 @@ import InfoList from '@/components/common/ResultModal/InfoList';
 import type { TypingResultType } from '@/components/common/ResultModal/types';
 import { BookmarkOff } from '@/icons/Heart';
 import Share from '@/icons/Share';
+import { getDateYYYYMMDDHHMMFormat } from '@/utils/time';
 
 interface ResultModalProps {
   isOpen: boolean;
   result: TypingResultType;
   onClose: () => void;
+  endTime: Date;
 
   title?: string;
 }
 
-export default function PracticeResultModal({ onClose, title, isOpen, result }: ResultModalProps) {
+export default function PracticeResultModal({ onClose, title, isOpen, result, endTime }: ResultModalProps) {
   const router = useRouter();
+  const isLong = !!title;
 
   const onBookmark = () => {
     console.log('click Bookmark: ');
@@ -51,7 +54,7 @@ export default function PracticeResultModal({ onClose, title, isOpen, result }: 
         <ModalHeader p={0}>
           <Flex justifyContent='space-between'>
             <Text fontSize='30px' fontWeight={700}>
-              짧은 글 연습모드 결과
+              {isLong ? '긴 글' : '짧은 글'} 연습모드 결과
             </Text>
             <Flex gap='14px'>
               <IconButton onAction={onShare} icon={<Share />} />
@@ -59,7 +62,7 @@ export default function PracticeResultModal({ onClose, title, isOpen, result }: 
             </Flex>
           </Flex>
           <Text color='gray.dark' fontSize='14px' fontWeight={500}>
-            2023.03.20 13:23
+            {getDateYYYYMMDDHHMMFormat(endTime)}
           </Text>
         </ModalHeader>
 

--- a/client/src/components/common/ResultModal/practice-mode.tsx
+++ b/client/src/components/common/ResultModal/practice-mode.tsx
@@ -13,11 +13,12 @@ import {
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
+import Alert from '@/components/common/Alert';
 import IconButton from '@/components/common/IconButton';
 import InfoList from '@/components/common/ResultModal/InfoList';
 import type { TypingResultType } from '@/components/common/ResultModal/types';
+import useToggle from '@/hooks/useToggle';
 import { BookmarkOff } from '@/icons/Heart';
-import Share from '@/icons/Share';
 import { getDateYYYYMMDDHHMMFormat } from '@/utils/time';
 
 interface ResultModalProps {
@@ -31,14 +32,13 @@ interface ResultModalProps {
 
 export default function PracticeResultModal({ onClose, title, isOpen, result, endTime }: ResultModalProps) {
   const router = useRouter();
+
+  const [isPrepareModalOpen, togglePrepareModal] = useToggle();
+
   const isLong = !!title;
 
   const onBookmark = () => {
-    console.log('click Bookmark: ');
-  };
-
-  const onShare = () => {
-    console.log('click Share: ', onShare);
+    togglePrepareModal();
   };
 
   const onReplay = () => {
@@ -47,49 +47,51 @@ export default function PracticeResultModal({ onClose, title, isOpen, result, en
   };
 
   return (
-    // TODO : Modal border radius 수정
-    <Modal isOpen={isOpen} onClose={onReplay} size='md'>
-      <ModalOverlay />
-      <ModalContent m='auto' p='49px 40px 42px'>
-        <ModalHeader p={0}>
-          <Flex justifyContent='space-between'>
-            <Text fontSize='30px' fontWeight={700}>
-              {isLong ? '긴 글' : '짧은 글'} 연습모드 결과
-            </Text>
-            <Flex gap='14px'>
-              <IconButton onAction={onShare} icon={<Share />} />
-              <IconButton onAction={onBookmark} icon={<BookmarkOff />} />
+    <>
+      <Modal isOpen={isOpen} onClose={onReplay} size='md'>
+        <ModalOverlay />
+        <ModalContent m='auto' p='49px 40px 42px'>
+          <ModalHeader p={0}>
+            <Flex justifyContent='space-between'>
+              <Text fontSize='30px' fontWeight={700}>
+                {isLong ? '긴 글' : '짧은 글'} 연습모드 결과
+              </Text>
+              <Flex gap='14px'>
+                {/* <IconButton onAction={onShare} icon={<Share />} /> */}
+                <IconButton onAction={onBookmark} icon={<BookmarkOff />} />
+              </Flex>
             </Flex>
-          </Flex>
-          <Text color='gray.dark' fontSize='14px' fontWeight={500}>
-            {getDateYYYYMMDDHHMMFormat(endTime)}
-          </Text>
-        </ModalHeader>
+            <Text color='gray.dark' fontSize='14px' fontWeight={500}>
+              {getDateYYYYMMDDHHMMFormat(endTime)}
+            </Text>
+          </ModalHeader>
 
-        <ModalBody mt='32px' mb='53px' p={0}>
-          <Flex gap='65px' w='100%'>
-            <Box w='100%'>
-              {title && (
-                <Text fontSize='19px' fontWeight={600} color='black.dark' mb='14px'>
-                  {title}
-                </Text>
-              )}
+          <ModalBody mt='32px' mb='53px' p={0}>
+            <Flex gap='65px' w='100%'>
+              <Box w='100%'>
+                {title && (
+                  <Text fontSize='19px' fontWeight={600} color='black.dark' mb='14px'>
+                    {title}
+                  </Text>
+                )}
 
-              <InfoList {...result} />
-            </Box>
-          </Flex>
-        </ModalBody>
-        <ModalFooter justifyContent='center' p='0' gap='17px'>
-          <Button w='174px' onClick={onReplay}>
-            이어 하기
-          </Button>
-          <Link href='/'>
-            <Button w='174px' variant='outline'>
-              메인화면으로 가기
+                <InfoList {...result} />
+              </Box>
+            </Flex>
+          </ModalBody>
+          <ModalFooter justifyContent='center' p='0' gap='17px'>
+            <Button w='174px' onClick={onReplay}>
+              이어 하기
             </Button>
-          </Link>
-        </ModalFooter>
-      </ModalContent>
-    </Modal>
+            <Link href='/'>
+              <Button w='174px' variant='outline'>
+                메인화면으로 가기
+              </Button>
+            </Link>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+      <Alert header='준비중인 기능입니다.' isOpen={isPrepareModalOpen} onClose={togglePrepareModal} />
+    </>
   );
 }

--- a/client/src/components/common/ResultModal/types.ts
+++ b/client/src/components/common/ResultModal/types.ts
@@ -1,6 +1,0 @@
-export interface TypingResultType {
-  typingTime: number;
-  typingAccuracy: number;
-  typingWpm: number;
-  typingSpeed: number;
-}

--- a/client/src/components/practice/short/_hook/contextShortTyping.tsx
+++ b/client/src/components/practice/short/_hook/contextShortTyping.tsx
@@ -74,7 +74,10 @@ const ShortTypingProvider = ({ children, originalTypings }: ShortTypingProviderP
 
   const saveTypingHistory = useCallback(
     (content: string) => {
-      history.current = [...history.current, { typingSpeed, typingAccuracy, typingWpm, typingTime: time, content }];
+      history.current = [
+        ...history.current,
+        { typingSpeed, typingAccuracy, typingWpm, typingTime: time, content, endTime: new Date() },
+      ];
     },
     [time, typingAccuracy, typingSpeed, typingWpm],
   );
@@ -112,6 +115,8 @@ const ShortTypingProvider = ({ children, originalTypings }: ShortTypingProviderP
     [currentIdx, handleResultModalToggle, handleSubmit, originalTypings.length],
   );
 
+  // NOTE: 모달 관련된 로직들을 분리할 방법이 있을까요?
+  // timePause, timePlay를 사용해야 하기떄문에 이곳에 만들었습니다.
   const handleExitModalOpen = useCallback(() => {
     timePause();
     handleExitModalToggle();
@@ -161,7 +166,12 @@ const ShortTypingProvider = ({ children, originalTypings }: ShortTypingProviderP
           actionLabel='그만하기'
           closeLabel='계속하기'
         />
-        <ResultModal isOpen={isResultModalOpen} onClose={handleResultModalToggle} result={typingAvgResult} />
+        <ResultModal
+          isOpen={isResultModalOpen}
+          onClose={handleResultModalToggle}
+          result={typingAvgResult}
+          endTime={history.current[history.current.length - 1]?.endTime ?? new Date()}
+        />
       </ContextShortTypingHandler.Provider>
     </ContextShortTyping.Provider>
   );

--- a/client/src/components/practice/short/_hook/contextShortTyping.tsx
+++ b/client/src/components/practice/short/_hook/contextShortTyping.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import type { ReactNode } from 'react';
 import { useCallback } from 'react';
 import { createContext, useContext, useMemo, useRef, useState } from 'react';
@@ -43,6 +44,7 @@ interface ShortTypingProviderProps {
 }
 
 const ShortTypingProvider = ({ children, originalTypings }: ShortTypingProviderProps) => {
+  const router = useRouter();
   const [currentIdx, setCurrentIdx] = useState(0);
 
   const {
@@ -132,6 +134,12 @@ const ShortTypingProvider = ({ children, originalTypings }: ShortTypingProviderP
     handleResultModalToggle();
   }, [handleExitModalToggle, handleResultModalToggle]);
 
+  const handleReplay = () => {
+    // NOTE : 다시하기 기능은 새로고침으로 구현했는데, 긴글에서도 새로고침으로 해도 괜찮을까요?
+    handleResultModalToggle();
+    router.reload();
+  };
+
   // NOTE: 객체의 크기가 커서, 알아보기 힘들다면 쪼개는 것도 좋을 것 같다.
   const values = {
     originalTyping,
@@ -168,9 +176,9 @@ const ShortTypingProvider = ({ children, originalTypings }: ShortTypingProviderP
         />
         <ResultModal
           isOpen={isResultModalOpen}
-          onClose={handleResultModalToggle}
           result={typingAvgResult}
           endTime={history.current[history.current.length - 1]?.endTime ?? new Date()}
+          onReplay={handleReplay}
         />
       </ContextShortTypingHandler.Provider>
     </ContextShortTyping.Provider>

--- a/client/src/types/typing.ts
+++ b/client/src/types/typing.ts
@@ -42,6 +42,7 @@ export interface TypingResultType {
 
 export interface TypingHistoryType extends TypingResultType {
   content: string;
+  endTime: Date;
 }
 
 export const INIT_TYPING_RESULT = {

--- a/client/src/utils/time.ts
+++ b/client/src/utils/time.ts
@@ -11,3 +11,14 @@ export const getSecondToMMSSFormat = (seconds: number) => {
 
   return `${minFormat}:${secFormat}`;
 };
+
+export const getDateYYYYMMDDHHMMFormat = (date: Date) => {
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+
+  const formattedDate = `${year}.${month}.${day} ${hours}:${minutes}`;
+  return formattedDate;
+};


### PR DESCRIPTION
## 📄 구현 내용 설명
연습모드 결과 모달 수정
<img width="1106" alt="image" src="https://user-images.githubusercontent.com/49177223/229054806-3f545e5f-963e-43d4-9110-b3345c216ad9.png">

### ⛱️ 주요 변경 사항

- 북마크 기능 -> "준비중인 기능"
- 연습모드의 경우 로그인 한경우에만 전적 저장

### 🙋 이 부분을 리뷰해주세요

- 다시하기 기능을 새로고침으로 구현해도 괜찮을까요? (짧은글은 가능합니다.)
- "준비중인 기능입니다" Alert을 만들었습니다. 그런데 어색한거 같아서, 어떻게 수정하면 좋을지 알려주시면 좋을것 같아요!
- 연습모드의 경우 로그인 없이 플레이가 가능하기 때문에, 액세스 토큰이 없으면 전적을 저장하지 않도록 구현하였습니다. 
혹시 액세스 토큰이 아닌 recoil에 저장된 유저정보로 판별하는 것이 좋을까요?

### 🤔 여기를 참고하면 도움이 돼요

-   [링크 이름](링크 주소)
-
