### PR TITLE
긴글 목록 조회시 전체페이지 목록개수도 return

### DIFF
--- a/backend/src/main/java/com/project/Tamago/controller/TypingController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TypingController.java
@@ -16,6 +16,7 @@ import com.project.Tamago.common.Response.CustomResponse;
 import com.project.Tamago.common.exception.InvalidParameterException;
 import com.project.Tamago.dto.Login;
 import com.project.Tamago.dto.responseDto.LongTypingDetailResDto;
+import com.project.Tamago.dto.LongTypingDto;
 import com.project.Tamago.dto.responseDto.LongTypingResDto;
 import com.project.Tamago.dto.responseDto.ShortTypingListResDto;
 import com.project.Tamago.common.exception.CustomException;
@@ -47,7 +48,7 @@ public class TypingController {
 	}
 
 	@GetMapping("/long")
-	public CustomResponse<List<LongTypingResDto>> findLongTypings(
+	public CustomResponse<LongTypingResDto> findLongTypings(
 		@RequestParam(required = false, defaultValue = "1") int page) {
 		return new CustomResponse<>(longTypingService.findLongTypings(page));
 	}

--- a/backend/src/main/java/com/project/Tamago/dto/LongTypingDto.java
+++ b/backend/src/main/java/com/project/Tamago/dto/LongTypingDto.java
@@ -1,0 +1,15 @@
+package com.project.Tamago.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class LongTypingDto {
+	private Integer typingId;
+	private String title;
+	private String thumbnail;
+	private String language;
+	private String totalPage;
+	private Integer viewCount;
+}

--- a/backend/src/main/java/com/project/Tamago/dto/mapper/DataMapper.java
+++ b/backend/src/main/java/com/project/Tamago/dto/mapper/DataMapper.java
@@ -14,7 +14,7 @@ import com.project.Tamago.dto.PageContentDto;
 import com.project.Tamago.dto.requestDto.LongTypingReqDto;
 import com.project.Tamago.dto.requestDto.TypingHistoryReqDto;
 import com.project.Tamago.dto.responseDto.LongTypingDetailResDto;
-import com.project.Tamago.dto.responseDto.LongTypingResDto;
+import com.project.Tamago.dto.LongTypingDto;
 import com.project.Tamago.security.CustomOAuth2User;
 
 @Mapper(componentModel = "spring")
@@ -24,7 +24,7 @@ public interface DataMapper {
 
 	@Mapping(source = "id", target = "typingId")
 	@Mapping(target = "language", expression = "java(longTyping.getLanguage().toString())")
-	LongTypingResDto LongTypingToLongTypingResDto(LongTyping longTyping);
+	LongTypingDto LongTypingToLongTypingResDto(LongTyping longTyping);
 
 	@Mapping(source = "longTyping.id", target = "typingId")
 	@Mapping(target = "language", expression = "java(longTyping.getLanguage().toString())")

--- a/backend/src/main/java/com/project/Tamago/dto/responseDto/LongTypingResDto.java
+++ b/backend/src/main/java/com/project/Tamago/dto/responseDto/LongTypingResDto.java
@@ -1,15 +1,15 @@
 package com.project.Tamago.dto.responseDto;
 
-import lombok.Builder;
+import java.util.List;
+
+import com.project.Tamago.dto.LongTypingDto;
+
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
-@Builder
+@AllArgsConstructor
 public class LongTypingResDto {
-	private Integer typingId;
-	private String title;
-	private String thumbnail;
-	private String language;
-	private String totalPage;
-	private Integer viewCount;
+	private Integer totalPage;
+	private List<LongTypingDto> longTypings;
 }

--- a/backend/src/main/java/com/project/Tamago/service/LongTypingService.java
+++ b/backend/src/main/java/com/project/Tamago/service/LongTypingService.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,10 +17,10 @@ import com.project.Tamago.dto.PageContentDto;
 import com.project.Tamago.dto.mapper.DataMapper;
 import com.project.Tamago.dto.requestDto.LongTypingReqDto;
 import com.project.Tamago.dto.responseDto.LongTypingDetailResDto;
-import com.project.Tamago.dto.responseDto.LongTypingResDto;
+import com.project.Tamago.dto.LongTypingDto;
 import com.project.Tamago.common.exception.CustomException;
+import com.project.Tamago.dto.responseDto.LongTypingResDto;
 import com.project.Tamago.repository.LongTypingRepository;
-import com.project.Tamago.repository.PagePositionRepository;
 import com.project.Tamago.repository.RegisterRepository;
 import com.project.Tamago.repository.UserRepository;
 
@@ -37,11 +38,15 @@ public class LongTypingService {
 	private final RegisterRepository registerRepository;
 
 	@Transactional(readOnly = true)
-	public List<LongTypingResDto> findLongTypings(int page) {
+	public LongTypingResDto findLongTypings(int page) {
 		PageRequest pageRequest = PageRequest.of(page - 1, 20);
-		return longTypingRepository.findAll(pageRequest).stream()
+		Page<LongTyping> longTypingPage = longTypingRepository.findAll(pageRequest);
+		List<LongTypingDto> longTypings = longTypingPage.stream()
 			.map(DataMapper.INSTANCE::LongTypingToLongTypingResDto)
 			.collect(Collectors.toList());
+		int totalPage = longTypingPage.getTotalPages();
+
+		return new LongTypingResDto(totalPage, longTypings);
 	}
 
 	@Transactional(readOnly = true)

--- a/backend/src/test/java/com/project/Tamago/service/LongTypingServiceTest.java
+++ b/backend/src/test/java/com/project/Tamago/service/LongTypingServiceTest.java
@@ -26,7 +26,7 @@ import com.project.Tamago.dto.PageContentDto;
 import com.project.Tamago.dto.mapper.DataMapper;
 import com.project.Tamago.dto.requestDto.LongTypingReqDto;
 import com.project.Tamago.dto.responseDto.LongTypingDetailResDto;
-import com.project.Tamago.dto.responseDto.LongTypingResDto;
+import com.project.Tamago.dto.LongTypingDto;
 import com.project.Tamago.repository.LongTypingRepository;
 import com.project.Tamago.repository.RegisterRepository;
 import com.project.Tamago.repository.UserRepository;
@@ -73,15 +73,15 @@ class LongTypingServiceTest {
 
 		when(longTypingRepository.findAll(any(PageRequest.class))).thenReturn(longTypingsPage);
 
-		List<LongTypingResDto> expectedLongTypingResDtos = longTypings.stream()
+		List<LongTypingDto> expectedLongTypingDtos = longTypings.stream()
 			.map(DataMapper.INSTANCE::LongTypingToLongTypingResDto)
 			.collect(Collectors.toList());
 
 		// when
-		List<LongTypingResDto> actualLongTypingResDtos = longTypingService.findLongTypings(1);
+		List<LongTypingDto> actualLongTypingDtos = longTypingService.findLongTypings(1).getLongTypings();
 
 		// then
-		assertEquals(expectedLongTypingResDtos, actualLongTypingResDtos);
+		assertEquals(expectedLongTypingDtos, actualLongTypingDtos);
 	}
 
 	@Test


### PR DESCRIPTION
## 📄 구현 내용 설명

### ⛱️ 주요 변경 사항

- 기존에 긴글목록 조회시 전체 페이지개수를 return안해서 그부분 고쳐서 올립니다
-

### 🙋 이 부분을 리뷰해주세요
![image](https://user-images.githubusercontent.com/78777461/229267579-db389ea1-e563-487b-a6f3-db3bbc107214.png)

