### PR TITLE
[#158] 에러로그를 slack으로 전송하는 모니터링 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -41,6 +41,11 @@ dependencies {
     // hypersistence-utils
     implementation 'io.hypersistence:hypersistence-utils-hibernate-55:3.2.0'
 
+    // slack Logback
+    implementation 'com.github.maricn:logback-slack-appender:1.4.0'
+    // webclient
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     // mapstruct
     compileOnly 'org.projectlombok:lombok'
     implementation 'org.mapstruct:mapstruct:1.4.2.Final'

--- a/backend/src/main/java/com/project/Tamago/TamagoApplication.java
+++ b/backend/src/main/java/com/project/Tamago/TamagoApplication.java
@@ -2,7 +2,12 @@ package com.project.Tamago;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import com.project.Tamago.common.logger.RequestStorage;
 
 @EnableJpaAuditing
 @SpringBootApplication

--- a/backend/src/main/java/com/project/Tamago/common/Constant.java
+++ b/backend/src/main/java/com/project/Tamago/common/Constant.java
@@ -7,5 +7,9 @@ public class Constant {
 	public static final String REFRESH_TOKEN = "refreshToken";
 	public static final String POSSIBLE_REISSUE = "possible reissue";
 	public static final String COLON = ":";
-
+	public static final String EXTRACTION_ERROR_MESSAGE = "메세지를 추출하는데 오류가 생겼습니다.\nmessagee : %s";
+	public static final String EXCEPTION_MESSAGE_FORMAT = "_%s_ %s.%s:%d - %s";
+	public static final String SLACK_MESSAGE_FORMAT = "*%s*\n*[요청한 멤버 id]* %s\n\n*[요청한 ip]* %s\n\n*[ERROR LOG]*\n%s\n\n*[REQUEST_INFORMATION]*\n%s %s\n%s";
+	public static final String EMPTY_BODY_MESSAGE = "{BODY IS EMPTY}";
+	public static final String SLACK_ALARM_FORMAT = "[SlackAlarm] %s";
 }

--- a/backend/src/main/java/com/project/Tamago/common/annotation/SlackAlarm.java
+++ b/backend/src/main/java/com/project/Tamago/common/annotation/SlackAlarm.java
@@ -1,0 +1,15 @@
+package com.project.Tamago.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.project.Tamago.common.enums.AlarmLevel;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SlackAlarm {
+
+	AlarmLevel level() default AlarmLevel.ERROR;
+}

--- a/backend/src/main/java/com/project/Tamago/common/enums/AlarmLevel.java
+++ b/backend/src/main/java/com/project/Tamago/common/enums/AlarmLevel.java
@@ -1,0 +1,9 @@
+package com.project.Tamago.common.enums;
+
+public enum AlarmLevel {
+	TRACE,
+	DEBUG,
+	INFO,
+	WARN,
+	ERROR
+}

--- a/backend/src/main/java/com/project/Tamago/common/exception/exceptionHandler/ControllerAdvice.java
+++ b/backend/src/main/java/com/project/Tamago/common/exception/exceptionHandler/ControllerAdvice.java
@@ -1,5 +1,6 @@
 package com.project.Tamago.common.exception.exceptionHandler;
 
+import static com.project.Tamago.common.enums.AlarmLevel.*;
 import static com.project.Tamago.common.enums.ResponseCode.*;
 
 import java.util.Arrays;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.project.Tamago.common.annotation.SlackAlarm;
 import com.project.Tamago.common.exception.CustomException;
 import com.project.Tamago.common.exception.InvalidParameterException;
 import com.project.Tamago.common.enums.ResponseCode;
@@ -24,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 @RestControllerAdvice
 public class ControllerAdvice {
 
+	@SlackAlarm(level = ERROR)
 	@org.springframework.web.bind.annotation.ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(InvalidParameterException.class)
 	protected ErrorMessage invalidParameterExceptionHandler(InvalidParameterException exception) {
@@ -32,6 +35,7 @@ public class ControllerAdvice {
 		return new ErrorMessage(responseCode, exception.getErrors());
 	}
 
+	@SlackAlarm(level = ERROR)
 	@org.springframework.web.bind.annotation.ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(MissingServletRequestParameterException.class)
 	protected ErrorMessage nullParameterExceptionHandler(MissingServletRequestParameterException exception) {
@@ -39,6 +43,7 @@ public class ControllerAdvice {
 		return new ErrorMessage(NULL_PARAMETER);
 	}
 
+	@SlackAlarm(level = ERROR)
 	@org.springframework.web.bind.annotation.ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ErrorMessage illegalArgumentExceptionHandler(IllegalArgumentException exception) {
@@ -46,6 +51,7 @@ public class ControllerAdvice {
 		return new ErrorMessage(INVALID_INPUT_VALUE);
 	}
 
+	@SlackAlarm(level = ERROR)
 	@org.springframework.web.bind.annotation.ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(InternalAuthenticationServiceException.class)
 	public ErrorMessage illegalArgumentExceptionHandler(InternalAuthenticationServiceException exception) {
@@ -53,6 +59,7 @@ public class ControllerAdvice {
 		return new ErrorMessage(USERS_EMPTY_USER_EMAIL);
 	}
 
+	@SlackAlarm(level = ERROR)
 	@org.springframework.web.bind.annotation.ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(BadCredentialsException.class)
 	public ErrorMessage illegalArgumentExceptionHandler(BadCredentialsException exception) {
@@ -60,6 +67,7 @@ public class ControllerAdvice {
 		return new ErrorMessage(USERS_EXISTS_PASSWORD);
 	}
 
+	@SlackAlarm(level = ERROR)
 	@org.springframework.web.bind.annotation.ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(CustomException.class)
 	public ErrorMessage customExceptionHandler(CustomException exception) {
@@ -69,6 +77,7 @@ public class ControllerAdvice {
 	}
 
 
+	@SlackAlarm(level = ERROR)
 	@org.springframework.web.bind.annotation.ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(HttpMessageNotReadableException.class)
 	public ErrorMessage customExceptionHandler(HttpMessageNotReadableException exception) {
@@ -77,6 +86,7 @@ public class ControllerAdvice {
 	}
 
 
+	@SlackAlarm(level = ERROR)
 	@org.springframework.web.bind.annotation.ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ErrorMessage customExceptionHandler(MethodArgumentNotValidException exception) {
@@ -84,6 +94,7 @@ public class ControllerAdvice {
 		return new ErrorMessage(INVALID_PARAMETER);
 	}
 
+	@SlackAlarm(level = ERROR)
 	@org.springframework.web.bind.annotation.ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 	@ExceptionHandler(Exception.class)
 	public ErrorMessage exceptionHandler(Exception exception) {

--- a/backend/src/main/java/com/project/Tamago/common/logger/RequestStorage.java
+++ b/backend/src/main/java/com/project/Tamago/common/logger/RequestStorage.java
@@ -1,0 +1,22 @@
+package com.project.Tamago.common.logger;
+
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+@Component
+@Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
+public class RequestStorage {
+
+	private  ContentCachingRequestWrapper request;
+
+	public void set(ContentCachingRequestWrapper request) {
+		this.request = request;
+	}
+
+	public ContentCachingRequestWrapper get() {
+		return request;
+	}
+}

--- a/backend/src/main/java/com/project/Tamago/common/logger/SlackAppender.java
+++ b/backend/src/main/java/com/project/Tamago/common/logger/SlackAppender.java
@@ -1,0 +1,77 @@
+package com.project.Tamago.common.logger;
+
+import static com.project.Tamago.common.Constant.*;
+import static com.project.Tamago.common.enums.AlarmLevel.*;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+import com.project.Tamago.common.annotation.SlackAlarm;
+import com.project.Tamago.common.enums.AlarmLevel;
+import com.project.Tamago.common.exception.CustomException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Component
+public class SlackAppender {
+	private final RequestStorage requestStorage;
+	private final SlackMessageGenerator slackMessageGenerator;
+	private final TamagoSlack tamagoSlack;
+
+	public SlackAppender(RequestStorage requestStorage, SlackMessageGenerator slackMessageGenerator,
+		TamagoSlack tamagoSlack) {
+		this.requestStorage = requestStorage;
+		this.slackMessageGenerator = slackMessageGenerator;
+		this.tamagoSlack = tamagoSlack;
+	}
+
+	public void appendExceptionToSlack(CustomException exception) {
+		String message = slackMessageGenerator.generateSlackErrorMessage(requestStorage.get(), exception, ERROR);
+		tamagoSlack.send(message);
+	}
+
+
+	@Before("@annotation(com.project.Tamago.common.annotation.SlackAlarm)")
+	public void appendExceptionToResponseBody(JoinPoint joinPoint) {
+		Object[] args = joinPoint.getArgs();
+		if (!validateHasOneArgument(args)) {
+			return;
+		}
+
+		if (!validateIsException(args)) {
+			return;
+		}
+
+		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
+		SlackAlarm slackAlarm = signature.getMethod().getAnnotation(SlackAlarm.class);
+		AlarmLevel alarmLevel = slackAlarm.level();
+
+		String message = slackMessageGenerator
+			.generateSlackErrorMessage(requestStorage.get(), (Exception)args[0], alarmLevel);
+		tamagoSlack.send(message);
+	}
+
+	private boolean validateIsException(Object[] args) {
+		if (!(args[0] instanceof Exception)) {
+			log.warn("[SlackAlarm] argument is not Exception");
+			return false;
+		}
+
+		return true;
+	}
+
+	private boolean validateHasOneArgument(Object[] args) {
+		if (args.length != 1) {
+			log.warn(String
+				.format(SLACK_ALARM_FORMAT, "ambiguous exceptions! require just only one Exception"));
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/backend/src/main/java/com/project/Tamago/common/logger/SlackMessageGenerator.java
+++ b/backend/src/main/java/com/project/Tamago/common/logger/SlackMessageGenerator.java
@@ -1,0 +1,95 @@
+package com.project.Tamago.common.logger;
+
+import static com.project.Tamago.common.Constant.*;
+
+import java.net.InetAddress;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import com.project.Tamago.common.enums.AlarmLevel;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SlackMessageGenerator {
+	private final Environment environment;
+
+	public String generateSlackErrorMessage(ContentCachingRequestWrapper request, Exception exception,
+		AlarmLevel level) {
+		try {
+			String currentTime = getCurrentTime();
+			String userId = (String)request.getAttribute("userId");
+			String method = request.getMethod();
+			String exceptionMessage = extractExceptionMessage(exception, level);
+			String requestURI = request.getRequestURI();
+			String body = getBody(request);
+			String ip = request.getHeader("X-Forwarded-For");
+			if (ip == null || ip.isBlank()) {
+				ip = InetAddress.getLocalHost().getHostAddress();
+			}
+			return toMessage(currentTime, userId, ip,
+				exceptionMessage, method, requestURI, body);
+		} catch (Exception e) {
+			return String.format(EXTRACTION_ERROR_MESSAGE, e.getMessage());
+		}
+	}
+
+	private String getCurrentTime() {
+		return LocalDateTime.now().toString();
+	}
+
+	private String extractRequestHeaders(ContentCachingRequestWrapper request) {
+		Map<String, String> headers = new HashMap<>();
+		StringJoiner headerJoiner = new StringJoiner("\n");
+
+		for (String headerName : Collections.list(request.getHeaderNames())) {
+			headers.put(headerName, request.getHeader(headerName));
+		}
+		for (Map.Entry<String, String> header : headers.entrySet()) {
+			headerJoiner.add(header.getKey() + ":" + header.getValue());
+		}
+		return headerJoiner.toString();
+	}
+
+	private String getBody(ContentCachingRequestWrapper request) {
+		String body = new String(request.getContentAsByteArray());
+		if (body.isEmpty()) {
+			body = EMPTY_BODY_MESSAGE;
+		}
+		return body;
+	}
+
+	private String extractExceptionMessage(Exception e, AlarmLevel level) {
+		StackTraceElement stackTrace = e.getStackTrace()[0];
+		String message = e.getMessage();
+
+		if (Objects.isNull(message)) {
+			return Arrays.stream(e.getStackTrace())
+				.map(StackTraceElement::toString)
+				.collect(Collectors.joining("\n"));
+		}
+
+		return String.format(EXCEPTION_MESSAGE_FORMAT, level.name(), stackTrace.getClassName(),
+			stackTrace.getMethodName(), stackTrace.getLineNumber(), message);
+	}
+
+	private String toMessage(String currentTime, String userId, String ip, String errorMessage,
+		String method, String requestURI, String body) {
+		return String.format(
+			SLACK_MESSAGE_FORMAT, currentTime, userId, ip,
+			errorMessage, method, requestURI, body
+		);
+	}
+}
+

--- a/backend/src/main/java/com/project/Tamago/common/logger/TamagoSlack.java
+++ b/backend/src/main/java/com/project/Tamago/common/logger/TamagoSlack.java
@@ -1,0 +1,44 @@
+package com.project.Tamago.common.logger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TamagoSlack {
+
+	private final ObjectMapper objectMapper;
+	@Value("${logging.slack.webhook-uri}")
+	private String SLACK_LOGGER_WEBHOOK_URI;
+
+
+	public void send(String message) {
+		WebClient.create(SLACK_LOGGER_WEBHOOK_URI)
+			.post()
+			.contentType(MediaType.APPLICATION_JSON)
+			.bodyValue(toJson(message))
+			.retrieve()
+			.bodyToMono(String.class)
+			.subscribe();
+	}
+
+	private String toJson(String message) {
+		try {
+			Map<String, String> values = new HashMap<>();
+			values.put("text", message);
+			return objectMapper.writeValueAsString(values);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException("Failed to serialize message to JSON", e);
+		}
+	}
+}

--- a/backend/src/main/java/com/project/Tamago/common/response/CustomResponse.java
+++ b/backend/src/main/java/com/project/Tamago/common/response/CustomResponse.java
@@ -1,4 +1,4 @@
-package com.project.Tamago.common.Response;
+package com.project.Tamago.common.response;
 
 import static com.project.Tamago.common.enums.ResponseCode.*;
 

--- a/backend/src/main/java/com/project/Tamago/configuration/config/CorsConfig.java
+++ b/backend/src/main/java/com/project/Tamago/configuration/config/CorsConfig.java
@@ -1,4 +1,4 @@
-package com.project.Tamago.config;
+package com.project.Tamago.configuration.config;
 
 import java.util.List;
 

--- a/backend/src/main/java/com/project/Tamago/configuration/config/RedisConfig.java
+++ b/backend/src/main/java/com/project/Tamago/configuration/config/RedisConfig.java
@@ -1,4 +1,4 @@
-package com.project.Tamago.config;
+package com.project.Tamago.configuration.config;
 
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;

--- a/backend/src/main/java/com/project/Tamago/configuration/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/project/Tamago/configuration/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.project.Tamago.config;
+package com.project.Tamago.configuration.config;
 
 import static com.project.Tamago.common.Constant.*;
 

--- a/backend/src/main/java/com/project/Tamago/configuration/config/WebConfig.java
+++ b/backend/src/main/java/com/project/Tamago/configuration/config/WebConfig.java
@@ -1,16 +1,22 @@
-package com.project.Tamago.config;
+package com.project.Tamago.configuration.config;
 
 import java.util.List;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.project.Tamago.common.logger.RequestStorage;
+import com.project.Tamago.configuration.resolver.LoginArgumentResolver;
 
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Configuration
-public class ResolverConfig implements WebMvcConfigurer {
+public class WebConfig implements WebMvcConfigurer {
 	private final LoginArgumentResolver loginArgumentResolver;
 
 	@Override

--- a/backend/src/main/java/com/project/Tamago/configuration/resolver/LoginArgumentResolver.java
+++ b/backend/src/main/java/com/project/Tamago/configuration/resolver/LoginArgumentResolver.java
@@ -1,4 +1,4 @@
-package com.project.Tamago.config;
+package com.project.Tamago.configuration.resolver;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.context.SecurityContextHolder;

--- a/backend/src/main/java/com/project/Tamago/controller/AuthController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/AuthController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.project.Tamago.common.Response.CustomResponse;
+import com.project.Tamago.common.response.CustomResponse;
 import com.project.Tamago.dto.requestDto.JoinReqDto;
 import com.project.Tamago.dto.requestDto.LoginReqDto;
 import com.project.Tamago.dto.requestDto.PasswordReqDto;
@@ -49,7 +49,10 @@ public class AuthController {
 	}
 
 	@PostMapping("/login")
-	public CustomResponse<LoginResDto> login(@Validated @RequestBody LoginReqDto loginReqDto) {
+	public CustomResponse<LoginResDto> login(@Validated @RequestBody LoginReqDto loginReqDto, BindingResult result) {
+		if (result.hasErrors()) {
+			throw new InvalidParameterException(result);
+		}
 		return new CustomResponse<>(authService.login(loginReqDto));
 	}
 

--- a/backend/src/main/java/com/project/Tamago/controller/StatisticController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/StatisticController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.project.Tamago.common.Response.CustomResponse;
+import com.project.Tamago.common.response.CustomResponse;
 import com.project.Tamago.dto.Login;
 import com.project.Tamago.dto.responseDto.DateAccuracyAverageResDto;
 import com.project.Tamago.dto.responseDto.DateWpmAverageResDto;

--- a/backend/src/main/java/com/project/Tamago/controller/TypingController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TypingController.java
@@ -1,6 +1,5 @@
 package com.project.Tamago.controller;
 
-import java.util.List;
 import java.util.stream.Stream;
 
 import org.springframework.validation.BindingResult;
@@ -12,11 +11,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.project.Tamago.common.Response.CustomResponse;
+import com.project.Tamago.common.response.CustomResponse;
 import com.project.Tamago.common.exception.InvalidParameterException;
 import com.project.Tamago.dto.Login;
 import com.project.Tamago.dto.responseDto.LongTypingDetailResDto;
-import com.project.Tamago.dto.LongTypingDto;
 import com.project.Tamago.dto.responseDto.LongTypingResDto;
 import com.project.Tamago.dto.responseDto.ShortTypingListResDto;
 import com.project.Tamago.common.exception.CustomException;

--- a/backend/src/main/java/com/project/Tamago/controller/TypingHistoryController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TypingHistoryController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.project.Tamago.common.Response.CustomResponse;
+import com.project.Tamago.common.response.CustomResponse;
 import com.project.Tamago.dto.Login;
 import com.project.Tamago.dto.requestDto.TypingHistoryReqDto;
 import com.project.Tamago.common.exception.InvalidParameterException;

--- a/backend/src/main/java/com/project/Tamago/controller/UserController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/UserController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.project.Tamago.common.Response.CustomResponse;
+import com.project.Tamago.common.response.CustomResponse;
 import com.project.Tamago.dto.Login;
 import com.project.Tamago.dto.requestDto.ModifyProfileReqDto;
 import com.project.Tamago.dto.responseDto.ProfileResDto;

--- a/backend/src/main/java/com/project/Tamago/security/jwt/JwtAuthorizationFilter.java
+++ b/backend/src/main/java/com/project/Tamago/security/jwt/JwtAuthorizationFilter.java
@@ -1,5 +1,7 @@
 package com.project.Tamago.security.jwt;
 
+import static com.project.Tamago.common.enums.AlarmLevel.*;
+
 import java.io.IOException;
 
 import javax.servlet.FilterChain;
@@ -13,8 +15,12 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
 
+import com.project.Tamago.common.annotation.SlackAlarm;
 import com.project.Tamago.common.exception.CustomException;
+import com.project.Tamago.common.exception.exceptionHandler.ErrorMessage;
+import com.project.Tamago.common.logger.RequestStorage;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,15 +31,18 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
 	private final JwtTokenProvider jwtTokenProvider;
 	private final RedisTemplate<String, Object> redisTemplate;
+	private final RequestStorage requestStorage;
 
 	@Override
-	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+	public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
 		throws IOException, ServletException {
-		String token = jwtTokenProvider.resolveToken(request);
+		ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(request);
+		requestStorage.set(wrappedRequest);
+		String token = jwtTokenProvider.resolveToken(wrappedRequest);
 
 		if (!StringUtils.hasText(token)) {
-			request.setAttribute("exception", "");
-			chain.doFilter(request, response);
+			wrappedRequest.setAttribute("exception", "");
+			chain.doFilter(wrappedRequest, response);
 			return;
 		}
 		try {
@@ -45,11 +54,11 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 				String userId = authentication.getName();
 				SecurityContextHolder.getContext().setAuthentication(authentication);
 
-				request.setAttribute("userId", userId);
+				wrappedRequest.setAttribute("userId", userId);
 			}
 		} catch (CustomException e) {
-			request.setAttribute("exception", e.getErrorCode().getCode());
+			wrappedRequest.setAttribute("exception", e.getErrorCode().getCode());
 		}
-		chain.doFilter(request, response);
+		chain.doFilter(wrappedRequest, response);
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/security/jwt/handler/CustomAccessDeniedHandler.java
+++ b/backend/src/main/java/com/project/Tamago/security/jwt/handler/CustomAccessDeniedHandler.java
@@ -10,10 +10,12 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@Component
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 	@Override
 	public void handle(

--- a/backend/src/main/java/com/project/Tamago/security/jwt/handler/CustomAuthenticationEntryPointHandler.java
+++ b/backend/src/main/java/com/project/Tamago/security/jwt/handler/CustomAuthenticationEntryPointHandler.java
@@ -1,5 +1,6 @@
 package com.project.Tamago.security.jwt.handler;
 
+import static com.project.Tamago.common.enums.AlarmLevel.*;
 import static com.project.Tamago.common.enums.ResponseCode.*;
 
 import java.io.IOException;
@@ -9,20 +10,30 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.aspectj.lang.JoinPoint;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
 
 import com.project.Tamago.common.enums.ResponseCode;
+import com.project.Tamago.common.exception.CustomException;
+import com.project.Tamago.common.logger.SlackAppender;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class CustomAuthenticationEntryPointHandler implements AuthenticationEntryPoint {
 	private final ResponseCode[] responseCodes = {EMPTY_JWT, EXPIRED_JWT, INVALID_JWT, INVALID_SIGNATURE};
+	private final SlackAppender slackAppender;
 
 	@Override
 	public void commence(HttpServletRequest request, HttpServletResponse response,
-		AuthenticationException authException) throws IOException,
-		ServletException {
+		AuthenticationException authException) throws IOException, ServletException {
 		String exception = String.valueOf(request.getAttribute("exception"));
-
 		ResponseCode responseCode = Arrays.stream(responseCodes)
 			.filter(ec -> exception.equals(ec.getCode() + ""))
 			.findFirst()
@@ -30,13 +41,15 @@ public class CustomAuthenticationEntryPointHandler implements AuthenticationEntr
 
 		if (responseCode != null) {
 			setResponse(response, responseCode);
+			slackAppender.appendExceptionToSlack(new CustomException(responseCode));
 		}
 		if (exception.isEmpty()) {
 			setResponse(response, EMPTY_JWT);
+			slackAppender.appendExceptionToSlack(new CustomException(EMPTY_JWT));
 		}
 	}
-
 	private void setResponse(HttpServletResponse response, ResponseCode responseCode) throws IOException {
+		log.error(responseCode.getDescription());
 		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 		response.setContentType("application/json;charset=UTF-8");
 		response.getWriter().write("{" + "\"code\":\"" + responseCode.getCode() + "\","


### PR DESCRIPTION
## 📄 구현 내용 설명
- closes - #158 
- 기존의 에러로그들을 swagger를 통해서 확인하는 방식에서 slack으로도 실시간으로 에러로그를 모니터링하면 어떨까싶어 적용해보았습니다
- 예전에 한번해봤던 방식에서 aop를 통해서 재구현해보았습니
### ⛱️ 주요 변경 사항
![image](https://user-images.githubusercontent.com/78777461/229384820-58c78f3f-3a2c-438a-afd2-a4a6fffd9edf.png)

- 예전에 구현방식은 logback-spring.xml을 통해서 하드코딩된 값들을 로깅하는 방식이였는데 request의 ip와 uri등 request를 가공하기 어려운 단점과 에러를 던지는 곳과 에러를 전송하는곳 두군데다 코드를 많이 작성해야하다보니 비효율적이였습니다
    - 무엇보다 httpservletRequest를 사용하는곳 전부에서 가공하고 메소드마다 설정해야하는 코드가 많다보니 별로
- 그렇기때문에 aop에서 해당 request를 캐싱해서 request scope가 관리하는 reqeust Storage에 저장한후 @slackAlarm 어노테이션이 작성된 메소드가 호출될때 slack으로 로그를 전송하는 slackAppender가 트리거되는 방식을 적용했습니다
- config디렉토리를 configuration 디렉토리로하고 하위디렉토리로 config,resolver로 세분화했습니다

### 🙋 이 부분을 리뷰해주세요

- slackAlarm, slackAppender, TamagoSlack, jwtAutorizaionfilter, controllerAdvice를 보시면됩니다
- slackAlarm = AOP클래스인 slackAppender가 트리거되도록하는 어노테이션 에러메소드에 붙습니다
- slackAppender = slack으로 로그를 전송하기위한 aop클래스
- TamagoSlack = slack으로 로그를 전송하는 기능을 실질적으로 담당합니다 webclient를 이용해서 비동기적으로 슬랙으로 로그를 전송합니다
- jwtAutorizationFilter = 해당 filter에서 request를 캐싱해 requestStorage에 넣습니다 requestStorage의 경우 requestScope로 관리됩니다
- controllerAdvice = 에러들을 return 합니다 또한 slackAlarm어노테이션이 붙어있습니다

### 🤔 여기를 참고하면 도움이 돼요

- [webclient](https://vprog1215.tistory.com/374)
- [scope](https://chung-develop.tistory.com/64)
- [기본적인 구현 틀](https://devlog-wjdrbs96.tistory.com/327)
-   [도움이 정말 많이된 블로그](https://bperhaps.tistory.com/entry/Spring-Slack-Alarm-Logger-%EB%A7%8C%EB%93%A4%EA%B8%B0)
-
