### PR TITLE
vscode의 typescript 버전 업그레이드로 인한 ts server 에러 수정

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,6 @@
     "typescriptreact"
   ],
   "editor.tabSize": 2,
+  "typescript.tsdk": "client/node_modules/typescript/lib",
   "cSpell.words": ["chartjs", "YYYYMMDDHHMM"]
 }


### PR DESCRIPTION
## 📄 구현 내용 설명
typescript 버전이 4 -> 5 로 올라가면서 발생하던 ts 서버 에러를 수정했습니다.

[typescript 레포에 이슈](https://github.com/microsoft/TypeScript/issues/53234)들을 뒤져봤는데, 다른 사람들도 겪고 있는 이슈들이었고, ts 버전이 4에서 5로 올라가면서 발생하는 이슈임을 확인했습니다.

따라서 ts 서버를 vscode에 설치된 서버가 아니라, 저희 플젝에 있는 ts server를 선택하도록 타게팅을 변경했습니다.

아래와 같이 하시면 됩니다.

#### 1. 이 pr을 머지해주세요!

#### 2. 머지한 후 아무 tsx 파일을 열고, F1을 눌러서 설정 검색 -> 아래 사진과 같이 ts 버전을 선택하는 옵션 선택
![image](https://user-images.githubusercontent.com/59170680/229765756-103de2ab-5e65-4cc7-aad2-389302ac1065.png)

#### 3. 기존 옵션이 아니라, "Use Workspace Version" 선택
![image](https://user-images.githubusercontent.com/59170680/229766328-168eeec8-967d-47f5-bb38-06c4a5d24f5f.png)

#### 4. 해결!
