### PR TITLE
[#259] 긴글,짧은글 실전 api 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -41,6 +41,11 @@ dependencies {
     // hypersistence-utils
     implementation 'io.hypersistence:hypersistence-utils-hibernate-55:3.2.0'
 
+    // slack Logback
+    implementation 'com.github.maricn:logback-slack-appender:1.4.0'
+    // webclient
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     // mapstruct
     compileOnly 'org.projectlombok:lombok'
     implementation 'org.mapstruct:mapstruct:1.4.2.Final'

--- a/backend/src/main/java/com/project/Tamago/TamagoApplication.java
+++ b/backend/src/main/java/com/project/Tamago/TamagoApplication.java
@@ -2,7 +2,12 @@ package com.project.Tamago;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import com.project.Tamago.common.logger.RequestStorage;
 
 @EnableJpaAuditing
 @SpringBootApplication

--- a/backend/src/main/java/com/project/Tamago/common/Constant.java
+++ b/backend/src/main/java/com/project/Tamago/common/Constant.java
@@ -7,5 +7,9 @@ public class Constant {
 	public static final String REFRESH_TOKEN = "refreshToken";
 	public static final String POSSIBLE_REISSUE = "possible reissue";
 	public static final String COLON = ":";
-
+	public static final String EXTRACTION_ERROR_MESSAGE = "메세지를 추출하는데 오류가 생겼습니다.\nmessagee : %s";
+	public static final String EXCEPTION_MESSAGE_FORMAT = "_%s_ %s.%s:%d - %s";
+	public static final String SLACK_MESSAGE_FORMAT = "*%s*\n*[요청한 멤버 id]* %s\n\n*[요청한 ip]* %s\n\n*[ERROR LOG]*\n%s\n\n*[REQUEST_INFORMATION]*\n%s %s\n%s";
+	public static final String EMPTY_BODY_MESSAGE = "{BODY IS EMPTY}";
+	public static final String SLACK_ALARM_FORMAT = "[SlackAlarm] %s";
 }

--- a/backend/src/main/java/com/project/Tamago/common/Constant.java
+++ b/backend/src/main/java/com/project/Tamago/common/Constant.java
@@ -12,4 +12,8 @@ public class Constant {
 	public static final String SLACK_MESSAGE_FORMAT = "*%s*\n*[요청한 멤버 id]* %s\n\n*[요청한 ip]* %s\n\n*[ERROR LOG]*\n%s\n\n*[REQUEST_INFORMATION]*\n%s %s\n%s";
 	public static final String EMPTY_BODY_MESSAGE = "{BODY IS EMPTY}";
 	public static final String SLACK_ALARM_FORMAT = "[SlackAlarm] %s";
+	public static final int PRACTICE_SHORT_TYPING_SIZE = 30;
+	public static final int EXAM_SHORT_TYPING_SIZE = 10;
+
+
 }

--- a/backend/src/main/java/com/project/Tamago/common/annotation/SlackAlarm.java
+++ b/backend/src/main/java/com/project/Tamago/common/annotation/SlackAlarm.java
@@ -1,0 +1,15 @@
+package com.project.Tamago.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.project.Tamago.common.enums.AlarmLevel;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SlackAlarm {
+
+	AlarmLevel level() default AlarmLevel.ERROR;
+}

--- a/backend/src/main/java/com/project/Tamago/common/enums/AlarmLevel.java
+++ b/backend/src/main/java/com/project/Tamago/common/enums/AlarmLevel.java
@@ -1,0 +1,9 @@
+package com.project.Tamago.common.enums;
+
+public enum AlarmLevel {
+	TRACE,
+	DEBUG,
+	INFO,
+	WARN,
+	ERROR
+}

--- a/backend/src/main/java/com/project/Tamago/common/enums/Score.java
+++ b/backend/src/main/java/com/project/Tamago/common/enums/Score.java
@@ -1,0 +1,17 @@
+package com.project.Tamago.common.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum Score {
+	TIER_2_DIFF(20),
+	TIER_1_DIFF(10),
+	PENALTY(5),
+	SAME_TIER(15);
+
+	private final int score;
+
+	Score(int score) {
+		this.score = score;
+	}
+}

--- a/backend/src/main/java/com/project/Tamago/common/exception/exceptionHandler/ControllerAdvice.java
+++ b/backend/src/main/java/com/project/Tamago/common/exception/exceptionHandler/ControllerAdvice.java
@@ -1,5 +1,6 @@
 package com.project.Tamago.common.exception.exceptionHandler;
 
+import static com.project.Tamago.common.enums.AlarmLevel.*;
 import static com.project.Tamago.common.enums.ResponseCode.*;
 
 import java.util.Arrays;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.project.Tamago.common.annotation.SlackAlarm;
 import com.project.Tamago.common.exception.CustomException;
 import com.project.Tamago.common.exception.InvalidParameterException;
 import com.project.Tamago.common.enums.ResponseCode;
@@ -24,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 @RestControllerAdvice
 public class ControllerAdvice {
 
+	@SlackAlarm(level = ERROR)
 	@org.springframework.web.bind.annotation.ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(InvalidParameterException.class)
 	protected ErrorMessage invalidParameterExceptionHandler(InvalidParameterException exception) {
@@ -32,6 +35,7 @@ public class ControllerAdvice {
 		return new ErrorMessage(responseCode, exception.getErrors());
 	}
 
+	@SlackAlarm(level = ERROR)
 	@org.springframework.web.bind.annotation.ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(MissingServletRequestParameterException.class)
 	protected ErrorMessage nullParameterExceptionHandler(MissingServletRequestParameterException exception) {
@@ -39,6 +43,7 @@ public class ControllerAdvice {
 		return new ErrorMessage(NULL_PARAMETER);
 	}
 
+	@SlackAlarm(level = ERROR)
 	@org.springframework.web.bind.annotation.ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ErrorMessage illegalArgumentExceptionHandler(IllegalArgumentException exception) {
@@ -46,6 +51,7 @@ public class ControllerAdvice {
 		return new ErrorMessage(INVALID_INPUT_VALUE);
 	}
 
+	@SlackAlarm(level = ERROR)
 	@org.springframework.web.bind.annotation.ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(InternalAuthenticationServiceException.class)
 	public ErrorMessage illegalArgumentExceptionHandler(InternalAuthenticationServiceException exception) {
@@ -53,6 +59,7 @@ public class ControllerAdvice {
 		return new ErrorMessage(USERS_EMPTY_USER_EMAIL);
 	}
 
+	@SlackAlarm(level = ERROR)
 	@org.springframework.web.bind.annotation.ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(BadCredentialsException.class)
 	public ErrorMessage illegalArgumentExceptionHandler(BadCredentialsException exception) {
@@ -60,6 +67,7 @@ public class ControllerAdvice {
 		return new ErrorMessage(USERS_EXISTS_PASSWORD);
 	}
 
+	@SlackAlarm(level = ERROR)
 	@org.springframework.web.bind.annotation.ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(CustomException.class)
 	public ErrorMessage customExceptionHandler(CustomException exception) {
@@ -69,6 +77,7 @@ public class ControllerAdvice {
 	}
 
 
+	@SlackAlarm(level = ERROR)
 	@org.springframework.web.bind.annotation.ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(HttpMessageNotReadableException.class)
 	public ErrorMessage customExceptionHandler(HttpMessageNotReadableException exception) {
@@ -77,6 +86,7 @@ public class ControllerAdvice {
 	}
 
 
+	@SlackAlarm(level = ERROR)
 	@org.springframework.web.bind.annotation.ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ErrorMessage customExceptionHandler(MethodArgumentNotValidException exception) {
@@ -84,6 +94,7 @@ public class ControllerAdvice {
 		return new ErrorMessage(INVALID_PARAMETER);
 	}
 
+	@SlackAlarm(level = ERROR)
 	@org.springframework.web.bind.annotation.ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 	@ExceptionHandler(Exception.class)
 	public ErrorMessage exceptionHandler(Exception exception) {

--- a/backend/src/main/java/com/project/Tamago/common/logger/RequestStorage.java
+++ b/backend/src/main/java/com/project/Tamago/common/logger/RequestStorage.java
@@ -1,0 +1,22 @@
+package com.project.Tamago.common.logger;
+
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+@Component
+@Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
+public class RequestStorage {
+
+	private  ContentCachingRequestWrapper request;
+
+	public void set(ContentCachingRequestWrapper request) {
+		this.request = request;
+	}
+
+	public ContentCachingRequestWrapper get() {
+		return request;
+	}
+}

--- a/backend/src/main/java/com/project/Tamago/common/logger/SlackAppender.java
+++ b/backend/src/main/java/com/project/Tamago/common/logger/SlackAppender.java
@@ -1,0 +1,77 @@
+package com.project.Tamago.common.logger;
+
+import static com.project.Tamago.common.Constant.*;
+import static com.project.Tamago.common.enums.AlarmLevel.*;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+import com.project.Tamago.common.annotation.SlackAlarm;
+import com.project.Tamago.common.enums.AlarmLevel;
+import com.project.Tamago.common.exception.CustomException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Component
+public class SlackAppender {
+	private final RequestStorage requestStorage;
+	private final SlackMessageGenerator slackMessageGenerator;
+	private final TamagoSlack tamagoSlack;
+
+	public SlackAppender(RequestStorage requestStorage, SlackMessageGenerator slackMessageGenerator,
+		TamagoSlack tamagoSlack) {
+		this.requestStorage = requestStorage;
+		this.slackMessageGenerator = slackMessageGenerator;
+		this.tamagoSlack = tamagoSlack;
+	}
+
+	public void appendExceptionToSlack(CustomException exception) {
+		String message = slackMessageGenerator.generateSlackErrorMessage(requestStorage.get(), exception, ERROR);
+		tamagoSlack.send(message);
+	}
+
+
+	@Before("@annotation(com.project.Tamago.common.annotation.SlackAlarm)")
+	public void appendExceptionToResponseBody(JoinPoint joinPoint) {
+		Object[] args = joinPoint.getArgs();
+		if (!validateHasOneArgument(args)) {
+			return;
+		}
+
+		if (!validateIsException(args)) {
+			return;
+		}
+
+		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
+		SlackAlarm slackAlarm = signature.getMethod().getAnnotation(SlackAlarm.class);
+		AlarmLevel alarmLevel = slackAlarm.level();
+
+		String message = slackMessageGenerator
+			.generateSlackErrorMessage(requestStorage.get(), (Exception)args[0], alarmLevel);
+		tamagoSlack.send(message);
+	}
+
+	private boolean validateIsException(Object[] args) {
+		if (!(args[0] instanceof Exception)) {
+			log.warn("[SlackAlarm] argument is not Exception");
+			return false;
+		}
+
+		return true;
+	}
+
+	private boolean validateHasOneArgument(Object[] args) {
+		if (args.length != 1) {
+			log.warn(String
+				.format(SLACK_ALARM_FORMAT, "ambiguous exceptions! require just only one Exception"));
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/backend/src/main/java/com/project/Tamago/common/logger/SlackMessageGenerator.java
+++ b/backend/src/main/java/com/project/Tamago/common/logger/SlackMessageGenerator.java
@@ -1,0 +1,95 @@
+package com.project.Tamago.common.logger;
+
+import static com.project.Tamago.common.Constant.*;
+
+import java.net.InetAddress;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import com.project.Tamago.common.enums.AlarmLevel;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SlackMessageGenerator {
+	private final Environment environment;
+
+	public String generateSlackErrorMessage(ContentCachingRequestWrapper request, Exception exception,
+		AlarmLevel level) {
+		try {
+			String currentTime = getCurrentTime();
+			String userId = (String)request.getAttribute("userId");
+			String method = request.getMethod();
+			String exceptionMessage = extractExceptionMessage(exception, level);
+			String requestURI = request.getRequestURI();
+			String body = getBody(request);
+			String ip = request.getHeader("X-Forwarded-For");
+			if (ip == null || ip.isBlank()) {
+				ip = InetAddress.getLocalHost().getHostAddress();
+			}
+			return toMessage(currentTime, userId, ip,
+				exceptionMessage, method, requestURI, body);
+		} catch (Exception e) {
+			return String.format(EXTRACTION_ERROR_MESSAGE, e.getMessage());
+		}
+	}
+
+	private String getCurrentTime() {
+		return LocalDateTime.now().toString();
+	}
+
+	private String extractRequestHeaders(ContentCachingRequestWrapper request) {
+		Map<String, String> headers = new HashMap<>();
+		StringJoiner headerJoiner = new StringJoiner("\n");
+
+		for (String headerName : Collections.list(request.getHeaderNames())) {
+			headers.put(headerName, request.getHeader(headerName));
+		}
+		for (Map.Entry<String, String> header : headers.entrySet()) {
+			headerJoiner.add(header.getKey() + ":" + header.getValue());
+		}
+		return headerJoiner.toString();
+	}
+
+	private String getBody(ContentCachingRequestWrapper request) {
+		String body = new String(request.getContentAsByteArray());
+		if (body.isEmpty()) {
+			body = EMPTY_BODY_MESSAGE;
+		}
+		return body;
+	}
+
+	private String extractExceptionMessage(Exception e, AlarmLevel level) {
+		StackTraceElement stackTrace = e.getStackTrace()[0];
+		String message = e.getMessage();
+
+		if (Objects.isNull(message)) {
+			return Arrays.stream(e.getStackTrace())
+				.map(StackTraceElement::toString)
+				.collect(Collectors.joining("\n"));
+		}
+
+		return String.format(EXCEPTION_MESSAGE_FORMAT, level.name(), stackTrace.getClassName(),
+			stackTrace.getMethodName(), stackTrace.getLineNumber(), message);
+	}
+
+	private String toMessage(String currentTime, String userId, String ip, String errorMessage,
+		String method, String requestURI, String body) {
+		return String.format(
+			SLACK_MESSAGE_FORMAT, currentTime, userId, ip,
+			errorMessage, method, requestURI, body
+		);
+	}
+}
+

--- a/backend/src/main/java/com/project/Tamago/common/logger/TamagoSlack.java
+++ b/backend/src/main/java/com/project/Tamago/common/logger/TamagoSlack.java
@@ -1,0 +1,44 @@
+package com.project.Tamago.common.logger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TamagoSlack {
+
+	private final ObjectMapper objectMapper;
+	@Value("${logging.slack.webhook-uri}")
+	private String SLACK_LOGGER_WEBHOOK_URI;
+
+
+	public void send(String message) {
+		WebClient.create(SLACK_LOGGER_WEBHOOK_URI)
+			.post()
+			.contentType(MediaType.APPLICATION_JSON)
+			.bodyValue(toJson(message))
+			.retrieve()
+			.bodyToMono(String.class)
+			.subscribe();
+	}
+
+	private String toJson(String message) {
+		try {
+			Map<String, String> values = new HashMap<>();
+			values.put("text", message);
+			return objectMapper.writeValueAsString(values);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException("Failed to serialize message to JSON", e);
+		}
+	}
+}

--- a/backend/src/main/java/com/project/Tamago/common/response/CustomResponse.java
+++ b/backend/src/main/java/com/project/Tamago/common/response/CustomResponse.java
@@ -1,4 +1,4 @@
-package com.project.Tamago.common.Response;
+package com.project.Tamago.common.response;
 
 import static com.project.Tamago.common.enums.ResponseCode.*;
 

--- a/backend/src/main/java/com/project/Tamago/configuration/config/CorsConfig.java
+++ b/backend/src/main/java/com/project/Tamago/configuration/config/CorsConfig.java
@@ -1,4 +1,4 @@
-package com.project.Tamago.config;
+package com.project.Tamago.configuration.config;
 
 import java.util.List;
 

--- a/backend/src/main/java/com/project/Tamago/configuration/config/RedisConfig.java
+++ b/backend/src/main/java/com/project/Tamago/configuration/config/RedisConfig.java
@@ -1,4 +1,4 @@
-package com.project.Tamago.config;
+package com.project.Tamago.configuration.config;
 
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;

--- a/backend/src/main/java/com/project/Tamago/configuration/config/SecurityConfig.java
+++ b/backend/src/main/java/com/project/Tamago/configuration/config/SecurityConfig.java
@@ -68,6 +68,7 @@ public class SecurityConfig {
 			// swagger
 			.antMatchers("/typing/history").authenticated()
 			.antMatchers("/typing/register").authenticated()
+			.antMatchers("/typing/exam").authenticated()
 			.antMatchers("/statistics/**").permitAll()
 			.antMatchers("/oauth2/**").permitAll()
 			.antMatchers("/auth/**").permitAll()

--- a/backend/src/main/java/com/project/Tamago/configuration/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/project/Tamago/configuration/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.project.Tamago.config;
+package com.project.Tamago.configuration.config;
 
 import static com.project.Tamago.common.Constant.*;
 

--- a/backend/src/main/java/com/project/Tamago/configuration/config/WebConfig.java
+++ b/backend/src/main/java/com/project/Tamago/configuration/config/WebConfig.java
@@ -1,16 +1,22 @@
-package com.project.Tamago.config;
+package com.project.Tamago.configuration.config;
 
 import java.util.List;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.project.Tamago.common.logger.RequestStorage;
+import com.project.Tamago.configuration.resolver.LoginArgumentResolver;
 
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Configuration
-public class ResolverConfig implements WebMvcConfigurer {
+public class WebConfig implements WebMvcConfigurer {
 	private final LoginArgumentResolver loginArgumentResolver;
 
 	@Override

--- a/backend/src/main/java/com/project/Tamago/configuration/resolver/LoginArgumentResolver.java
+++ b/backend/src/main/java/com/project/Tamago/configuration/resolver/LoginArgumentResolver.java
@@ -1,4 +1,4 @@
-package com.project.Tamago.config;
+package com.project.Tamago.configuration.resolver;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.context.SecurityContextHolder;

--- a/backend/src/main/java/com/project/Tamago/configuration/resolver/LoginArgumentResolver.java
+++ b/backend/src/main/java/com/project/Tamago/configuration/resolver/LoginArgumentResolver.java
@@ -8,13 +8,13 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-import com.project.Tamago.dto.Login;
+import com.project.Tamago.dto.LoginResolverDto;
 
 @Component
 public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
 	@Override
 	public boolean supportsParameter(MethodParameter parameter) {
-		return parameter.getParameterType().equals(Login.class) &&
+		return parameter.getParameterType().equals(LoginResolverDto.class) &&
 			parameter.hasParameterAnnotation(com.project.Tamago.common.annotation.Login.class);
 	}
 
@@ -22,6 +22,6 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
 	public Object resolveArgument(
 		MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
 		Integer userId = Integer.parseInt(SecurityContextHolder.getContext().getAuthentication().getName());
-		return new Login(userId);
+		return new LoginResolverDto(userId);
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/controller/AuthController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/AuthController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.project.Tamago.common.Response.CustomResponse;
+import com.project.Tamago.common.response.CustomResponse;
 import com.project.Tamago.dto.requestDto.JoinReqDto;
 import com.project.Tamago.dto.requestDto.LoginReqDto;
 import com.project.Tamago.dto.requestDto.PasswordReqDto;
@@ -49,7 +49,10 @@ public class AuthController {
 	}
 
 	@PostMapping("/login")
-	public CustomResponse<LoginResDto> login(@Validated @RequestBody LoginReqDto loginReqDto) {
+	public CustomResponse<LoginResDto> login(@Validated @RequestBody LoginReqDto loginReqDto, BindingResult result) {
+		if (result.hasErrors()) {
+			throw new InvalidParameterException(result);
+		}
 		return new CustomResponse<>(authService.login(loginReqDto));
 	}
 

--- a/backend/src/main/java/com/project/Tamago/controller/StatisticController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/StatisticController.java
@@ -8,8 +8,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.project.Tamago.common.annotation.Login;
 import com.project.Tamago.common.response.CustomResponse;
-import com.project.Tamago.dto.Login;
+import com.project.Tamago.dto.LoginResolverDto;
 import com.project.Tamago.dto.responseDto.DateAccuracyAverageResDto;
 import com.project.Tamago.dto.responseDto.DateWpmAverageResDto;
 import com.project.Tamago.dto.responseDto.StatisticsAllResDto;
@@ -25,26 +26,24 @@ public class StatisticController {
 	private final StatisticService statisticService;
 
 	@GetMapping("/all")
-	public CustomResponse<StatisticsAllResDto> findUserStatistic(@com.project.Tamago.common.annotation.Login Login login) {
-		return new CustomResponse<>(statisticService.totalStatisticsAll(login.getUserId()));
+	public CustomResponse<StatisticsAllResDto> findUserStatistic(@Login LoginResolverDto loginResolverDto) {
+		return new CustomResponse<>(statisticService.totalStatisticsAll(loginResolverDto.getUserId()));
 	}
 
 	@GetMapping("/speed")
-	public CustomResponse<DateWpmAverageResDto> findDateAverageWpm(
-		@com.project.Tamago.common.annotation.Login Login login,
+	public CustomResponse<DateWpmAverageResDto> findDateAverageWpm(@Login LoginResolverDto loginResolverDto,
 		@RequestParam("startDay") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDay,
 		@RequestParam("endDay") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDay) {
 		return new CustomResponse<>(
-			statisticService.findWpmAverageByUser(login.getUserId(), startDay, endDay));
+			statisticService.findWpmAverageByUser(loginResolverDto.getUserId(), startDay, endDay));
 	}
 
 	@GetMapping("/accuracy")
-	public CustomResponse<DateAccuracyAverageResDto> findDateAverageAccuracy(
-		@com.project.Tamago.common.annotation.Login Login login,
+	public CustomResponse<DateAccuracyAverageResDto> findDateAverageAccuracy(@Login LoginResolverDto loginResolverDto,
 		@RequestParam("startDay") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDay,
 		@RequestParam("endDay") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDay) {
 		return new CustomResponse<>(
-			statisticService.findAccuracyAverageByUser(login.getUserId(), startDay, endDay));
+			statisticService.findAccuracyAverageByUser(loginResolverDto.getUserId(), startDay, endDay));
 	}
 
 }

--- a/backend/src/main/java/com/project/Tamago/controller/StatisticController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/StatisticController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.project.Tamago.common.Response.CustomResponse;
+import com.project.Tamago.common.response.CustomResponse;
 import com.project.Tamago.dto.Login;
 import com.project.Tamago.dto.responseDto.DateAccuracyAverageResDto;
 import com.project.Tamago.dto.responseDto.DateWpmAverageResDto;

--- a/backend/src/main/java/com/project/Tamago/controller/TypingController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TypingController.java
@@ -11,10 +11,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.project.Tamago.common.annotation.Login;
 import com.project.Tamago.common.enums.Language;
 import com.project.Tamago.common.response.CustomResponse;
 import com.project.Tamago.common.exception.InvalidParameterException;
-import com.project.Tamago.dto.Login;
+import com.project.Tamago.dto.LoginResolverDto;
 import com.project.Tamago.dto.responseDto.LongTypingDetailResDto;
 import com.project.Tamago.dto.responseDto.LongTypingResDto;
 import com.project.Tamago.dto.responseDto.ShortTypingListResDto;
@@ -57,13 +58,13 @@ public class TypingController {
 	}
 
 	@PostMapping("/register")
-	public CustomResponse<Void> saveTyping(@com.project.Tamago.common.annotation.Login Login login,
+	public CustomResponse<Void> saveTyping(@Login LoginResolverDto loginResolverDto,
 		@Validated @RequestBody LongTypingReqDto longTypingReqDto,
 		BindingResult result) {
 		if (result.hasErrors()) {
 			throw new InvalidParameterException(result);
 		}
-		longTypingService.saveLongTyping(login.getUserId(), longTypingReqDto);
+		longTypingService.saveLongTyping(loginResolverDto.getUserId(), longTypingReqDto);
 		return new CustomResponse<>();
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/controller/TypingController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TypingController.java
@@ -41,7 +41,6 @@ public class TypingController {
 	public CustomResponse<ShortTypingListResDto> findShortTypings(@RequestParam String language) {
 		if (Stream.of(Language.values()).noneMatch(element -> element.name().equals(language)))
 			throw new CustomException(ResponseCode.INVALID_PARAMETER);
-
 		return new CustomResponse<>(shortTypingService.findRandomShortTyping(language));
 	}
 

--- a/backend/src/main/java/com/project/Tamago/controller/TypingController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TypingController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.project.Tamago.common.enums.Language;
 import com.project.Tamago.common.response.CustomResponse;
 import com.project.Tamago.common.exception.InvalidParameterException;
 import com.project.Tamago.dto.Login;
@@ -35,11 +36,10 @@ public class TypingController {
 
 	private final ShortTypingService shortTypingService;
 	private final LongTypingService longTypingService;
-	private static final String[] supportLanguage = {"korean", "english", "code"};
 
 	@GetMapping("/short")
 	public CustomResponse<ShortTypingListResDto> findShortTypings(@RequestParam String language) {
-		if (Stream.of(supportLanguage).noneMatch(element -> element.equals(language)))
+		if (Stream.of(Language.values()).noneMatch(element -> element.name().equals(language)))
 			throw new CustomException(ResponseCode.INVALID_PARAMETER);
 
 		return new CustomResponse<>(shortTypingService.findRandomShortTyping(language));

--- a/backend/src/main/java/com/project/Tamago/controller/TypingController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TypingController.java
@@ -1,6 +1,5 @@
 package com.project.Tamago.controller;
 
-import java.util.List;
 import java.util.stream.Stream;
 
 import org.springframework.validation.BindingResult;
@@ -12,11 +11,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.project.Tamago.common.Response.CustomResponse;
+import com.project.Tamago.common.response.CustomResponse;
 import com.project.Tamago.common.exception.InvalidParameterException;
 import com.project.Tamago.dto.Login;
 import com.project.Tamago.dto.responseDto.LongTypingDetailResDto;
-import com.project.Tamago.dto.LongTypingDto;
 import com.project.Tamago.dto.responseDto.LongTypingResDto;
 import com.project.Tamago.dto.responseDto.ShortTypingListResDto;
 import com.project.Tamago.common.exception.CustomException;

--- a/backend/src/main/java/com/project/Tamago/controller/TypingExamController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TypingExamController.java
@@ -4,7 +4,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.project.Tamago.common.annotation.Login;
 import com.project.Tamago.common.response.CustomResponse;
+import com.project.Tamago.dto.LoginResolverDto;
 import com.project.Tamago.dto.responseDto.LongTypingDetailResDto;
 import com.project.Tamago.service.LongTypingService;
 
@@ -21,7 +23,7 @@ public class TypingExamController {
 
 
 	@GetMapping("exam/long")
-	public CustomResponse<LongTypingDetailResDto> findLongExam() {
+	public CustomResponse<LongTypingDetailResDto> findLongExam(@Login LoginResolverDto loginResolverDto) {
 		return new CustomResponse<>(longTypingService.findLongExam());
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/controller/TypingExamController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TypingExamController.java
@@ -1,14 +1,23 @@
 package com.project.Tamago.controller;
 
+import java.util.stream.Stream;
+
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.project.Tamago.common.annotation.Login;
+import com.project.Tamago.common.enums.Language;
+import com.project.Tamago.common.enums.ResponseCode;
+import com.project.Tamago.common.exception.CustomException;
 import com.project.Tamago.common.response.CustomResponse;
 import com.project.Tamago.dto.LoginResolverDto;
 import com.project.Tamago.dto.responseDto.LongTypingDetailResDto;
+import com.project.Tamago.dto.responseDto.ShortTypingListResDto;
 import com.project.Tamago.service.LongTypingService;
+import com.project.Tamago.service.TypingExamService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,12 +27,21 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @RequestMapping("/typing")
 public class TypingExamController {
-
-	private final LongTypingService longTypingService;
-
+	private final TypingExamService typingExamService;
 
 	@GetMapping("exam/long")
-	public CustomResponse<LongTypingDetailResDto> findLongExam(@Login LoginResolverDto loginResolverDto) {
-		return new CustomResponse<>(longTypingService.findLongExam());
+	public CustomResponse<LongTypingDetailResDto> findLongExam(@RequestParam String language,
+		@Login LoginResolverDto loginResolverDto) {
+		if (Stream.of(Language.values()).noneMatch(element -> element.name().equals(language)))
+			throw new CustomException(ResponseCode.INVALID_PARAMETER);
+		return new CustomResponse<>(
+			typingExamService.findLongExam(loginResolverDto.getUserId(), Language.valueOf(language)));
+	}
+	@GetMapping("exam/short")
+	public CustomResponse<ShortTypingListResDto> findShortExam(@RequestParam String language,
+		@Login LoginResolverDto loginResolverDto) {
+		if (Stream.of(Language.values()).noneMatch(element -> element.name().equals(language)))
+			throw new CustomException(ResponseCode.INVALID_PARAMETER);
+		return new CustomResponse<>(typingExamService.findShortExam(loginResolverDto.getUserId(), Language.valueOf(language)));
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/controller/TypingExamController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TypingExamController.java
@@ -1,0 +1,27 @@
+package com.project.Tamago.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.project.Tamago.common.response.CustomResponse;
+import com.project.Tamago.dto.responseDto.LongTypingDetailResDto;
+import com.project.Tamago.service.LongTypingService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/typing")
+public class TypingExamController {
+
+	private final LongTypingService longTypingService;
+
+
+	@GetMapping("exam/long")
+	public CustomResponse<LongTypingDetailResDto> findLongExam() {
+		return new CustomResponse<>(longTypingService.findLongExam());
+	}
+}

--- a/backend/src/main/java/com/project/Tamago/controller/TypingHistoryController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TypingHistoryController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.project.Tamago.common.response.CustomResponse;
-import com.project.Tamago.dto.Login;
+import com.project.Tamago.dto.LoginResolverDto;
 import com.project.Tamago.dto.requestDto.TypingHistoryReqDto;
 import com.project.Tamago.common.exception.InvalidParameterException;
 import com.project.Tamago.service.TypingHistoryService;
@@ -24,11 +24,11 @@ public class TypingHistoryController {
 
 	@PostMapping("/history")
 	public CustomResponse<Void> saveTypingHistory(@RequestBody @Validated TypingHistoryReqDto typingHistoryReqDto,
-		@com.project.Tamago.common.annotation.Login Login login, BindingResult result) {
+		@com.project.Tamago.common.annotation.Login LoginResolverDto loginResolverDto, BindingResult result) {
 		if (result.hasErrors()) {
 			throw new InvalidParameterException(result);
 		}
-		typingHistoryService.saveHistory(typingHistoryReqDto, login.getUserId());
+		typingHistoryService.saveHistory(typingHistoryReqDto, loginResolverDto.getUserId());
 		return new CustomResponse<>();
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/controller/TypingHistoryController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TypingHistoryController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.project.Tamago.common.Response.CustomResponse;
+import com.project.Tamago.common.response.CustomResponse;
 import com.project.Tamago.dto.Login;
 import com.project.Tamago.dto.requestDto.TypingHistoryReqDto;
 import com.project.Tamago.common.exception.InvalidParameterException;

--- a/backend/src/main/java/com/project/Tamago/controller/UserController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/UserController.java
@@ -9,8 +9,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.project.Tamago.common.annotation.Login;
 import com.project.Tamago.common.response.CustomResponse;
-import com.project.Tamago.dto.Login;
+import com.project.Tamago.dto.LoginResolverDto;
 import com.project.Tamago.dto.requestDto.ModifyProfileReqDto;
 import com.project.Tamago.dto.responseDto.ProfileResDto;
 import com.project.Tamago.common.exception.InvalidParameterException;
@@ -26,23 +27,23 @@ public class UserController {
 	private final UserService userService;
 
 	@GetMapping("/profile")
-	public CustomResponse<ProfileResDto> findProfile(@com.project.Tamago.common.annotation.Login Login login) {
-		return new CustomResponse<>(userService.findProfileById(login.getUserId()));
+	public CustomResponse<ProfileResDto> findProfile(@Login LoginResolverDto loginResolverDto) {
+		return new CustomResponse<>(userService.findProfileById(loginResolverDto.getUserId()));
 	}
 
 	@PatchMapping("/profile")
-	public CustomResponse<Void> modifyProfile(@com.project.Tamago.common.annotation.Login Login login,
+	public CustomResponse<Void> modifyProfile(@Login LoginResolverDto loginResolverDto,
 		@Validated @RequestBody ModifyProfileReqDto modifyProfileReqDto, BindingResult result) {
 		if (result.hasErrors()) {
 			throw new InvalidParameterException(result);
 		}
-		userService.modifyUserById(login.getUserId(), modifyProfileReqDto);
+		userService.modifyUserById(loginResolverDto.getUserId(), modifyProfileReqDto);
 		return new CustomResponse<>();
 	}
 
 	@GetMapping("/typing/page")
-	public CustomResponse<Integer> findCurrentPage(@com.project.Tamago.common.annotation.Login Login login,
+	public CustomResponse<Integer> findCurrentPage(@Login LoginResolverDto loginResolverDto,
 		@RequestParam(required = true) Integer longTypingId) {
-		return new CustomResponse<>(userService.findCurrentPage(login.getUserId(), longTypingId));
+		return new CustomResponse<>(userService.findCurrentPage(loginResolverDto.getUserId(), longTypingId));
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/controller/UserController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/UserController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.project.Tamago.common.Response.CustomResponse;
+import com.project.Tamago.common.response.CustomResponse;
 import com.project.Tamago.dto.Login;
 import com.project.Tamago.dto.requestDto.ModifyProfileReqDto;
 import com.project.Tamago.dto.responseDto.ProfileResDto;

--- a/backend/src/main/java/com/project/Tamago/domain/Tier.java
+++ b/backend/src/main/java/com/project/Tamago/domain/Tier.java
@@ -46,8 +46,10 @@ public class Tier extends BaseTimeEntity {
 	@Enumerated(EnumType.STRING)
 	private Language language;
 
+	@ColumnDefault("1")
 	private Integer level;
 
+	@ColumnDefault("0")
 	private Integer mmr;
 
 	@ColumnDefault("false")

--- a/backend/src/main/java/com/project/Tamago/domain/Tier.java
+++ b/backend/src/main/java/com/project/Tamago/domain/Tier.java
@@ -1,5 +1,7 @@
 package com.project.Tamago.domain;
 
+import java.time.LocalDateTime;
+
 import javax.persistence.Column;
 import javax.persistence.ConstraintMode;
 import javax.persistence.Entity;
@@ -13,6 +15,10 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+import org.springframework.security.core.parameters.P;
+
 import com.project.Tamago.common.enums.Language;
 import com.project.Tamago.common.enums.Mode;
 
@@ -24,6 +30,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
@@ -39,5 +46,18 @@ public class Tier extends BaseTimeEntity {
 	@Enumerated(EnumType.STRING)
 	private Language language;
 
+	private Integer level;
+
 	private Integer mmr;
+
+	@ColumnDefault("false")
+	private Boolean status;
+
+	public void applyPenalty(int penalty) {
+		this.mmr = Math.max(0, this.mmr - penalty);
+		this.status = true;
+	}
+	public void initStatus() {
+		this.status = false;
+	}
 }

--- a/backend/src/main/java/com/project/Tamago/domain/Tier.java
+++ b/backend/src/main/java/com/project/Tamago/domain/Tier.java
@@ -1,0 +1,43 @@
+package com.project.Tamago.domain;
+
+import javax.persistence.Column;
+import javax.persistence.ConstraintMode;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import com.project.Tamago.common.enums.Language;
+import com.project.Tamago.common.enums.Mode;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Tier extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+	private User user;
+
+	@Enumerated(EnumType.STRING)
+	private Language language;
+
+	private Integer mmr;
+}

--- a/backend/src/main/java/com/project/Tamago/dto/LoginResolverDto.java
+++ b/backend/src/main/java/com/project/Tamago/dto/LoginResolverDto.java
@@ -7,6 +7,6 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 @Builder
-public class Login {
+public class LoginResolverDto {
 	private Integer userId;
 }

--- a/backend/src/main/java/com/project/Tamago/repository/LongTypingRepository.java
+++ b/backend/src/main/java/com/project/Tamago/repository/LongTypingRepository.java
@@ -5,13 +5,14 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.project.Tamago.domain.LongTyping;
 
 @Repository
 public interface LongTypingRepository extends JpaRepository<LongTyping, Integer> {
-	@Query(value = "SELECT * FROM long_typing ORDER BY RAND() LIMIT 1", nativeQuery = true)
-	Optional<LongTyping> findRandom();
+	@Query(value = "SELECT * FROM long_typing WHERE language = :language ORDER BY RAND() LIMIT 1", nativeQuery = true)
+	Optional<LongTyping> findRandomByLanguage(@Param("language") String language);
 	Optional<LongTyping> findByIdAndTotalPageGreaterThanEqual(Integer typingId, Integer page);
 }

--- a/backend/src/main/java/com/project/Tamago/repository/LongTypingRepository.java
+++ b/backend/src/main/java/com/project/Tamago/repository/LongTypingRepository.java
@@ -1,13 +1,17 @@
 package com.project.Tamago.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.project.Tamago.domain.LongTyping;
 
 @Repository
 public interface LongTypingRepository extends JpaRepository<LongTyping, Integer> {
+	@Query(value = "SELECT * FROM long_typing ORDER BY RAND() LIMIT 1", nativeQuery = true)
+	Optional<LongTyping> findRandom();
 	Optional<LongTyping> findByIdAndTotalPageGreaterThanEqual(Integer typingId, Integer page);
 }

--- a/backend/src/main/java/com/project/Tamago/repository/RegisterRepository.java
+++ b/backend/src/main/java/com/project/Tamago/repository/RegisterRepository.java
@@ -1,9 +1,11 @@
 package com.project.Tamago.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import com.project.Tamago.domain.PagePosition;
 import com.project.Tamago.domain.Register;
 
+@Repository
 public interface RegisterRepository extends JpaRepository<Register, Integer> {
 }

--- a/backend/src/main/java/com/project/Tamago/repository/StatisticAllRepository.java
+++ b/backend/src/main/java/com/project/Tamago/repository/StatisticAllRepository.java
@@ -3,10 +3,12 @@ package com.project.Tamago.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import com.project.Tamago.domain.StatisticsAll;
 import com.project.Tamago.domain.User;
 
+@Repository
 public interface StatisticAllRepository extends JpaRepository<StatisticsAll, Integer> {
 
 	Optional<StatisticsAll> findByUser(User user);

--- a/backend/src/main/java/com/project/Tamago/repository/TierRepository.java
+++ b/backend/src/main/java/com/project/Tamago/repository/TierRepository.java
@@ -1,0 +1,16 @@
+package com.project.Tamago.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.project.Tamago.common.enums.Language;
+import com.project.Tamago.domain.Tier;
+
+@Repository
+public interface TierRepository extends JpaRepository<Tier, Integer> {
+	boolean existsByUserIdAndLanguage(Integer userId, Language language);
+
+	Optional<Tier> findByUserIdAndLanguage(Integer userId, Language language);
+}

--- a/backend/src/main/java/com/project/Tamago/security/jwt/JwtAuthorizationFilter.java
+++ b/backend/src/main/java/com/project/Tamago/security/jwt/JwtAuthorizationFilter.java
@@ -1,5 +1,7 @@
 package com.project.Tamago.security.jwt;
 
+import static com.project.Tamago.common.enums.AlarmLevel.*;
+
 import java.io.IOException;
 
 import javax.servlet.FilterChain;
@@ -13,8 +15,12 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
 
+import com.project.Tamago.common.annotation.SlackAlarm;
 import com.project.Tamago.common.exception.CustomException;
+import com.project.Tamago.common.exception.exceptionHandler.ErrorMessage;
+import com.project.Tamago.common.logger.RequestStorage;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,15 +31,18 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
 	private final JwtTokenProvider jwtTokenProvider;
 	private final RedisTemplate<String, Object> redisTemplate;
+	private final RequestStorage requestStorage;
 
 	@Override
-	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+	public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
 		throws IOException, ServletException {
-		String token = jwtTokenProvider.resolveToken(request);
+		ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(request);
+		requestStorage.set(wrappedRequest);
+		String token = jwtTokenProvider.resolveToken(wrappedRequest);
 
 		if (!StringUtils.hasText(token)) {
-			request.setAttribute("exception", "");
-			chain.doFilter(request, response);
+			wrappedRequest.setAttribute("exception", "");
+			chain.doFilter(wrappedRequest, response);
 			return;
 		}
 		try {
@@ -45,11 +54,11 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 				String userId = authentication.getName();
 				SecurityContextHolder.getContext().setAuthentication(authentication);
 
-				request.setAttribute("userId", userId);
+				wrappedRequest.setAttribute("userId", userId);
 			}
 		} catch (CustomException e) {
-			request.setAttribute("exception", e.getErrorCode().getCode());
+			wrappedRequest.setAttribute("exception", e.getErrorCode().getCode());
 		}
-		chain.doFilter(request, response);
+		chain.doFilter(wrappedRequest, response);
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/security/jwt/handler/CustomAccessDeniedHandler.java
+++ b/backend/src/main/java/com/project/Tamago/security/jwt/handler/CustomAccessDeniedHandler.java
@@ -10,10 +10,12 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@Component
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 	@Override
 	public void handle(

--- a/backend/src/main/java/com/project/Tamago/security/jwt/handler/CustomAuthenticationEntryPointHandler.java
+++ b/backend/src/main/java/com/project/Tamago/security/jwt/handler/CustomAuthenticationEntryPointHandler.java
@@ -1,5 +1,6 @@
 package com.project.Tamago.security.jwt.handler;
 
+import static com.project.Tamago.common.enums.AlarmLevel.*;
 import static com.project.Tamago.common.enums.ResponseCode.*;
 
 import java.io.IOException;
@@ -9,20 +10,30 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.aspectj.lang.JoinPoint;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
 
 import com.project.Tamago.common.enums.ResponseCode;
+import com.project.Tamago.common.exception.CustomException;
+import com.project.Tamago.common.logger.SlackAppender;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class CustomAuthenticationEntryPointHandler implements AuthenticationEntryPoint {
 	private final ResponseCode[] responseCodes = {EMPTY_JWT, EXPIRED_JWT, INVALID_JWT, INVALID_SIGNATURE};
+	private final SlackAppender slackAppender;
 
 	@Override
 	public void commence(HttpServletRequest request, HttpServletResponse response,
-		AuthenticationException authException) throws IOException,
-		ServletException {
+		AuthenticationException authException) throws IOException, ServletException {
 		String exception = String.valueOf(request.getAttribute("exception"));
-
 		ResponseCode responseCode = Arrays.stream(responseCodes)
 			.filter(ec -> exception.equals(ec.getCode() + ""))
 			.findFirst()
@@ -30,13 +41,15 @@ public class CustomAuthenticationEntryPointHandler implements AuthenticationEntr
 
 		if (responseCode != null) {
 			setResponse(response, responseCode);
+			slackAppender.appendExceptionToSlack(new CustomException(responseCode));
 		}
 		if (exception.isEmpty()) {
 			setResponse(response, EMPTY_JWT);
+			slackAppender.appendExceptionToSlack(new CustomException(EMPTY_JWT));
 		}
 	}
-
 	private void setResponse(HttpServletResponse response, ResponseCode responseCode) throws IOException {
+		log.error(responseCode.getDescription());
 		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 		response.setContentType("application/json;charset=UTF-8");
 		response.getWriter().write("{" + "\"code\":\"" + responseCode.getCode() + "\","

--- a/backend/src/main/java/com/project/Tamago/service/LongTypingService.java
+++ b/backend/src/main/java/com/project/Tamago/service/LongTypingService.java
@@ -2,7 +2,6 @@ package com.project.Tamago.service;
 
 import static com.project.Tamago.common.enums.ResponseCode.*;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -13,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.project.Tamago.domain.LongTyping;
 import com.project.Tamago.domain.User;
-import com.project.Tamago.dto.PageContentDto;
 import com.project.Tamago.dto.mapper.DataMapper;
 import com.project.Tamago.dto.requestDto.LongTypingReqDto;
 import com.project.Tamago.dto.responseDto.LongTypingDetailResDto;
@@ -23,8 +21,8 @@ import com.project.Tamago.dto.responseDto.LongTypingResDto;
 import com.project.Tamago.repository.LongTypingRepository;
 import com.project.Tamago.repository.RegisterRepository;
 import com.project.Tamago.repository.UserRepository;
+import com.project.Tamago.util.TypingUtil;
 
-import io.swagger.models.auth.In;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -33,7 +31,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Transactional
 public class LongTypingService {
-	private static final int LINES_PER_PAGE = 20;
 	private final UserRepository userRepository;
 	private final LongTypingRepository longTypingRepository;
 	private final RegisterRepository registerRepository;
@@ -55,15 +52,7 @@ public class LongTypingService {
 		LongTyping longTyping = longTypingRepository.findByIdAndTotalPageGreaterThanEqual(longTypingId, page)
 			.orElseThrow(() -> new CustomException(LONG_TYPING_INFO_NOT_EXISTS));
 		return DataMapper.INSTANCE.LongTypingToLongTypingDetailResDto(longTyping,
-			getPageContent(longTyping.getContent(), page));
-	}
-
-	@Transactional(readOnly = true)
-	public LongTypingDetailResDto findLongExam() {
-		LongTyping longTyping = longTypingRepository.findRandom()
-			.orElseThrow(() -> new CustomException(LONG_TYPING_INFO_NOT_EXISTS));
-		return DataMapper.INSTANCE.LongTypingToLongTypingDetailResDto(longTyping,
-			getPageContent(longTyping.getContent(), getRandomInt(longTyping.getTotalPage())));
+			TypingUtil.getPageContent(longTyping.getContent(), page));
 	}
 
 	public void saveLongTyping(Integer userId, LongTypingReqDto longTypingReqDto) {
@@ -72,17 +61,5 @@ public class LongTypingService {
 		longTypingRepository.save(longTyping);
 		registerRepository.save(
 			DataMapper.INSTANCE.toRegister(longTyping, null, user));
-	}
-
-	private PageContentDto getPageContent(String content, Integer page) {
-		String[] contentLines = content.split("\r\n");
-		int startIndex = (page - 1) * LINES_PER_PAGE;
-		int endIndex = Math.min(startIndex + LINES_PER_PAGE, contentLines.length);
-		String pageContent = String.join("\n", Arrays.copyOfRange(contentLines, startIndex, endIndex));
-		return new PageContentDto(page, pageContent);
-	}
-
-	private int getRandomInt(int n) {
-		return (int) (Math.random() * n) + 1;
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/service/LongTypingService.java
+++ b/backend/src/main/java/com/project/Tamago/service/LongTypingService.java
@@ -24,6 +24,7 @@ import com.project.Tamago.repository.LongTypingRepository;
 import com.project.Tamago.repository.RegisterRepository;
 import com.project.Tamago.repository.UserRepository;
 
+import io.swagger.models.auth.In;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -57,6 +58,14 @@ public class LongTypingService {
 			getPageContent(longTyping.getContent(), page));
 	}
 
+	@Transactional(readOnly = true)
+	public LongTypingDetailResDto findLongExam() {
+		LongTyping longTyping = longTypingRepository.findRandom()
+			.orElseThrow(() -> new CustomException(LONG_TYPING_INFO_NOT_EXISTS));
+		return DataMapper.INSTANCE.LongTypingToLongTypingDetailResDto(longTyping,
+			getPageContent(longTyping.getContent(), getRandomInt(longTyping.getTotalPage())));
+	}
+
 	public void saveLongTyping(Integer userId, LongTypingReqDto longTypingReqDto) {
 		User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(USERS_INFO_NOT_EXISTS));
 		LongTyping longTyping = DataMapper.INSTANCE.toLongTyping(longTypingReqDto);
@@ -71,5 +80,9 @@ public class LongTypingService {
 		int endIndex = Math.min(startIndex + LINES_PER_PAGE, contentLines.length);
 		String pageContent = String.join("\n", Arrays.copyOfRange(contentLines, startIndex, endIndex));
 		return new PageContentDto(page, pageContent);
+	}
+
+	private int getRandomInt(int n) {
+		return (int) (Math.random() * n) + 1;
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/service/ShortTypingService.java
+++ b/backend/src/main/java/com/project/Tamago/service/ShortTypingService.java
@@ -1,5 +1,7 @@
 package com.project.Tamago.service;
 
+import static com.project.Tamago.common.Constant.*;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -12,6 +14,7 @@ import com.project.Tamago.dto.ShortTypingDto;
 import com.project.Tamago.dto.mapper.TypingMapper;
 import com.project.Tamago.dto.responseDto.ShortTypingListResDto;
 import com.project.Tamago.repository.TypingRepository;
+import com.project.Tamago.util.TypingUtil;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,20 +24,10 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Transactional
 public class ShortTypingService {
-
-	private static final int SHORT_TYPING_SIZE = 30;
 	private final TypingRepository typingRepository;
 
 	public ShortTypingListResDto findRandomShortTyping(String language) {
-		List<ShortTypingDto> shortTypingDtos = getRandomLimit30(typingRepository.findByContentTypeIsFalseAndLanguageIs(language));
+		List<ShortTypingDto> shortTypingDtos = TypingUtil.getRandomShortTypings(typingRepository.findByContentTypeIsFalseAndLanguageIs(language), PRACTICE_SHORT_TYPING_SIZE);
 		return new ShortTypingListResDto(0, "practice", shortTypingDtos);
-	}
-
-	private List<ShortTypingDto> getRandomLimit30(List<Typing> shortTypingsAllList) {
-		Collections.shuffle(shortTypingsAllList);
-		return shortTypingsAllList.stream()
-			.limit(SHORT_TYPING_SIZE)
-			.map(TypingMapper::toShortTypingDto)
-			.collect(Collectors.toList());
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/service/TypingExamService.java
+++ b/backend/src/main/java/com/project/Tamago/service/TypingExamService.java
@@ -76,8 +76,6 @@ public class TypingExamService {
 		Tier newTier = Tier.builder()
 			.user(user)
 			.language(language)
-			.level(1)
-			.mmr(0)
 			.build();
 		tierRepository.save(newTier);
 	}

--- a/backend/src/main/java/com/project/Tamago/service/TypingExamService.java
+++ b/backend/src/main/java/com/project/Tamago/service/TypingExamService.java
@@ -1,0 +1,85 @@
+package com.project.Tamago.service;
+
+import static com.project.Tamago.common.Constant.*;
+import static com.project.Tamago.common.enums.ResponseCode.*;
+import static com.project.Tamago.common.enums.Score.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.project.Tamago.common.enums.Language;
+import com.project.Tamago.common.exception.CustomException;
+import com.project.Tamago.domain.LongTyping;
+import com.project.Tamago.domain.Tier;
+import com.project.Tamago.domain.User;
+import com.project.Tamago.dto.ShortTypingDto;
+import com.project.Tamago.dto.mapper.DataMapper;
+import com.project.Tamago.dto.responseDto.LongTypingDetailResDto;
+import com.project.Tamago.dto.responseDto.ShortTypingListResDto;
+import com.project.Tamago.repository.LongTypingRepository;
+import com.project.Tamago.repository.TierRepository;
+import com.project.Tamago.repository.TypingRepository;
+import com.project.Tamago.repository.UserRepository;
+import com.project.Tamago.util.TypingUtil;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TypingExamService {
+
+	private final LongTypingRepository longTypingRepository;
+	private final TypingRepository typingRepository;
+	private final TierRepository tierRepository;
+	private final UserRepository userRepository;
+
+	public LongTypingDetailResDto findLongExam(Integer userId, Language language) {
+		modifyTier(userId, language);
+		LongTyping longTyping = longTypingRepository.findRandomByLanguage(language.toString())
+			.orElseThrow(() -> new CustomException(LONG_TYPING_INFO_NOT_EXISTS));
+		return DataMapper.INSTANCE.LongTypingToLongTypingDetailResDto(longTyping,
+			TypingUtil.getPageContent(longTyping.getContent()));
+	}
+
+	public ShortTypingListResDto findShortExam(Integer userId, Language language) {
+		modifyTier(userId, language);
+		List<ShortTypingDto> shortTypings = TypingUtil.getRandomShortTypings(
+			typingRepository.findByContentTypeIsFalseAndLanguageIs(language.toString()), EXAM_SHORT_TYPING_SIZE);
+		return new ShortTypingListResDto(0, "practice", shortTypings);
+	}
+
+	private void modifyTier(Integer userId, Language language) {
+		Tier tier = tierRepository.findByUserIdAndLanguage(userId, language).orElse(null);
+		if (tier != null) {
+			modifyExistingTier(tier);
+			return;
+		}
+		createNewTier(userId, language);
+	}
+
+	private void modifyExistingTier(Tier tier) {
+		if (tier.getStatus()) {
+			tier.initStatus();
+			return;
+		}
+		tier.applyPenalty(PENALTY.getScore());
+	}
+
+	private void createNewTier(Integer userId, Language language) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(USERS_INFO_NOT_EXISTS));
+		Tier newTier = Tier.builder()
+			.user(user)
+			.language(language)
+			.level(1)
+			.mmr(0)
+			.build();
+		tierRepository.save(newTier);
+	}
+
+}

--- a/backend/src/main/java/com/project/Tamago/util/TypingUtil.java
+++ b/backend/src/main/java/com/project/Tamago/util/TypingUtil.java
@@ -1,0 +1,38 @@
+package com.project.Tamago.util;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.project.Tamago.domain.Typing;
+import com.project.Tamago.dto.PageContentDto;
+import com.project.Tamago.dto.ShortTypingDto;
+import com.project.Tamago.dto.mapper.TypingMapper;
+
+public class TypingUtil {
+
+	private static final int LINES_PER_PAGE = 20;
+
+	public static PageContentDto getPageContent(String content, Integer page) {
+		String[] contentLines = content.split("\r\n");
+		int startIndex = (page - 1) * LINES_PER_PAGE;
+		int endIndex = Math.min(startIndex + LINES_PER_PAGE, contentLines.length);
+		String pageContent = String.join("\n", Arrays.copyOfRange(contentLines, startIndex, endIndex));
+		return new PageContentDto(page, pageContent);
+	}
+
+	public static PageContentDto getPageContent(String content) {
+		int totalPages = (int) Math.ceil((double) content.split("\r\n").length / LINES_PER_PAGE);
+		int randomPage = (int) (Math.random() * totalPages) + 1;
+		return getPageContent(content, randomPage);
+	}
+
+	public static List<ShortTypingDto> getRandomShortTypings(List<Typing> shortTypingsAllList, int limit) {
+		Collections.shuffle(shortTypingsAllList);
+		return shortTypingsAllList.stream()
+			.limit(limit)
+			.map(TypingMapper::toShortTypingDto)
+			.collect(Collectors.toList());
+	}
+}

--- a/backend/src/test/java/com/project/Tamago/controller/TypingControllerTest.java
+++ b/backend/src/test/java/com/project/Tamago/controller/TypingControllerTest.java
@@ -27,7 +27,7 @@ public class TypingControllerTest {
 	public void findShortTypings() throws Exception {
 		// given
 		MultiValueMap<String, String> info = new LinkedMultiValueMap<>();
-		info.add("language", "korean");
+		info.add("language", "KOREAN");
 		// when
 		ResultActions resultActions = mockMvc.perform(get("/typing/short").params(info));
 		// then

--- a/backend/src/test/java/com/project/Tamago/service/TypingExamServiceTest.java
+++ b/backend/src/test/java/com/project/Tamago/service/TypingExamServiceTest.java
@@ -1,0 +1,72 @@
+package com.project.Tamago.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import com.project.Tamago.common.enums.Language;
+import com.project.Tamago.domain.LongTyping;
+import com.project.Tamago.domain.User;
+import com.project.Tamago.dto.responseDto.LongTypingDetailResDto;
+import com.project.Tamago.repository.LongTypingRepository;
+import com.project.Tamago.repository.TierRepository;
+import com.project.Tamago.repository.TypingRepository;
+import com.project.Tamago.repository.UserRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class TypingExamServiceTest {
+	@Autowired
+	private TypingExamService typingExamService;
+	@MockBean
+	private LongTypingRepository longTypingRepository;
+	@MockBean
+	private TypingRepository typingRepository;
+	@MockBean
+	private TierRepository tierRepository;
+	@MockBean
+	private UserRepository userRepository;
+
+	@Test
+	@WithMockUser(username = "1", authorities = {"ROLE_USER"})
+	public void findLongExamTest() {
+		// given
+		int userId = 1;
+		Language language = Language.ENGLISH;
+		String content = "line 1\r\nline 2\r\nline 3\r\nline 4\r\nline 5\r\nline 6\r\nline 7\r\nline 8\r\nline 9\r\nline 10\r\nline 11\r\nline 12\r\nline 13\r\nline 14\r\nline 15\r\nline 16\r\nline 17\r\nline 18\r\nline 19\r\nline 20\r\nline 21\r\nline 22\r\nline 23\r\nline 24\r\nline 25\r\nline 26\r\nline 27\r\nline 28\r\nline 29\r\nline 30";
+		LongTyping longTyping = LongTyping.builder()
+			.id(1)
+			.title("Test title 1")
+			.thumbnail("test_thumbnail1")
+			.language(Language.ENGLISH)
+			.totalPage(10)
+			.viewCount(100)
+			.content(content)
+			.build();
+
+		User user = User.builder()
+			.id(1)
+			.email("test@naver.com")
+			.nickname("test")
+			.password("1234")
+			.build();
+		
+		when(userRepository.findById(any())).thenReturn(Optional.ofNullable(user));
+		when(longTypingRepository.findRandomByLanguage(language.toString())).thenReturn(Optional.of(longTyping));
+
+		// when
+		LongTypingDetailResDto result = typingExamService.findLongExam(userId, language);
+
+		// then
+		assertNotNull(result);
+		assertEquals(result.getTitle(), longTyping.getTitle());
+	}
+}

--- a/client/src/components/password/complete/index.tsx
+++ b/client/src/components/password/complete/index.tsx
@@ -17,7 +17,7 @@ export default function PasswordChangeComplete() {
         <Text>비밀번호 변경을 완료하였습니다.</Text>
         <Text>가입된 이메일로 로그인 해 주세요.</Text>
         <Flex mt='54px' gap={5}>
-          <Link href='/login'>
+          <Link href='/loginResolverDto'>
             <Button>로그인하기</Button>
           </Link>
           <Link href='/'>

--- a/client/src/components/password/complete/index.tsx
+++ b/client/src/components/password/complete/index.tsx
@@ -17,7 +17,7 @@ export default function PasswordChangeComplete() {
         <Text>비밀번호 변경을 완료하였습니다.</Text>
         <Text>가입된 이메일로 로그인 해 주세요.</Text>
         <Flex mt='54px' gap={5}>
-          <Link href='/loginResolverDto'>
+          <Link href='/login'>
             <Button>로그인하기</Button>
           </Link>
           <Link href='/'>


### PR DESCRIPTION
## 📄 구현 내용 설명
- -#259
- 긴글 실전조회
- 짧은글 실전조회
### ⛱️ 주요 변경 사항

- 기존에 짧은글 랜덤으로 정렬하는 함수를 util클래스로 옮겼습니다
- 티어 테이블 생성했습니다 
- 실전모드의 경우 유저만 접근가능
- 실전모드의 경우 도중에나가서 다시 시험을 치려는 행위를 막기위해서 티어의 점수가 반영이 되었는지(status값)으로 검증하는 로직이있습니다 (modifyTier 함수) 해당 함수를 통해서 실전모드를 치르려는 글의 언어종류, 유저아이디에 대한 티어 필드값이 존재하는지 확인하고 존재하지않는다면 티어필드를 하나 생성하고 존재한다면 티어점수가 반영이되었는지 검증합니다
- 티어 점수 반영여부는 status로 판별하는데 기본값은 false입니다 true로 되어있다면 무사히 점수를 반영했다는 뜻으로 새 게임을 치르기위해서 다시 false로 바꿔주는로직이있습니다 false로 되어있다면 도중에 나갔다는 뜻이므로 패널티를 줘서 감점을 하는로직입니다

### 🙋 이 부분을 리뷰해주세요

- typingExamService코드를 유심히 봐주세요
- typingUtil 클래스를 만들었습니다 기존에 긴글에서 랜덤으로 글을 가져오는 로직도 확장성있게 오버로딩했습니다

### 🤔 여기를 참고하면 도움이 돼요

긴글 실전 api - typing/exam/long get -
- 시작전 탈주한게 있는지 확인하고 감점
- 램덤한 글의 랜덤한 페이지를 입력받기
- 긴글id
- 제목
- 내용

짧은글 실전 api - typing/short/exam get
- 시작전 탈주한게 있는지 확인하고 감점
- 10개 보내주기
- 연습모드와 다를게 없음 고민중
- 일단 supportLanguages부분 enum으로 대체 대문자로 하면됩니다

패널티 차감 typing/penalties post
실전모드 들어갈때 전적을 기록하는 방식으로 하는게 좋을듯

- 나가기버튼을 눌렀을때
i) 즉시 나간거 반영해서 점수기록하기
- 브라우저가 꺼졌을때 실저모드 들어갈때 확인해야겠다
i) 유저프로필을 가져올때 티어랑 점수가져오면서 나간거 여부체크하기 이후감점

