### PR TITLE
클라이언트의 ip를 제대로 반환하지못하는 에러

### DIFF
--- a/backend/src/main/java/com/project/Tamago/common/logger/SlackMessageGenerator.java
+++ b/backend/src/main/java/com/project/Tamago/common/logger/SlackMessageGenerator.java
@@ -35,8 +35,10 @@ public class SlackMessageGenerator {
 			String requestURI = request.getRequestURI();
 			String body = getBody(request);
 			String ip = request.getHeader("X-Forwarded-For");
-			if (ip == null || ip.isBlank()) {
-				ip = InetAddress.getLocalHost().getHostAddress();
+			if (ip != null && !ip.isBlank()) {
+				ip = ip.split(",")[0].trim();
+			} else {
+				ip = request.getRemoteAddr();
 			}
 			return toMessage(currentTime, userId, ip,
 				exceptionMessage, method, requestURI, body);


### PR DESCRIPTION
## 📄 구현 내용 설명
![image](https://user-images.githubusercontent.com/78777461/230048473-68e35685-4e28-4ddb-9578-ac8f5d425243.png)
현재 클라이언트의 ip를 가져오는 코드에서 제대로 못가져오는 문제가 생겨서 도커 컨테이너 내부 ip를 가져오는 에러가있었습니다 일단 코드를 고쳤는데 해결이되는지는 올려봐야알듯합니다..
