### PR TITLE
긴글 등록시 페이지를 제대로 분리못하는 에러 fix

### DIFF
--- a/backend/src/main/java/com/project/Tamago/dto/mapper/DataMapper.java
+++ b/backend/src/main/java/com/project/Tamago/dto/mapper/DataMapper.java
@@ -42,7 +42,7 @@ public interface DataMapper {
 
 	@Mapping(target = "thumbnail", expression = "java(longTypingReqDto.getContent().replaceAll(\"\\r\", \"\").substring(0, Math.min(longTypingReqDto.getContent().replaceAll(\"\\r\", \"\").length(), 50)))")
 	@Mapping(target = "length", expression = "java(longTypingReqDto.getContent().replaceAll(\"\\r\", \"\").length())")
-	@Mapping(target = "totalPage", expression = "java((int) Math.ceil((double) (longTypingReqDto.getContent().length() - longTypingReqDto.getContent().replaceAll(\"\\r\\n\", \"\").length() + 1) / 20))")
+	@Mapping(target = "totalPage", expression = "java((int) Math.ceil((double) (longTypingReqDto.getContent().length() - longTypingReqDto.getContent().replaceAll(\"\\n\", \"\").length() + 1) / 20))")
 	LongTyping toLongTyping(LongTypingReqDto longTypingReqDto);
 
 	@Mapping(target = "id", ignore = true)


### PR DESCRIPTION
## 📄 구현 내용 설명
긴글 등록시 \n을 replace해서 page를 분리하는 로직이있는데 sql insert할때는 \r\n을 리플레이스하다보니 mapstruct에서 그부분을 안고쳐서 페이지를 분리를 못하는 에러가 생겼습니다 
![image](https://user-images.githubusercontent.com/78777461/230073066-1baed3dc-4467-4cce-a868-4b399f92edc9.png)
