### PR TITLE
긴글 페이지 분리시 \n을 분리못하는 문제 해결

### DIFF
--- a/backend/src/main/java/com/project/Tamago/util/TypingUtil.java
+++ b/backend/src/main/java/com/project/Tamago/util/TypingUtil.java
@@ -15,7 +15,7 @@ public class TypingUtil {
 	private static final int LINES_PER_PAGE = 20;
 
 	public static PageContentDto getPageContent(String content, Integer page) {
-		String[] contentLines = content.split("\r\n");
+		String[] contentLines = content.replaceAll("\r\n", "\n").split("\n");
 		int startIndex = (page - 1) * LINES_PER_PAGE;
 		int endIndex = Math.min(startIndex + LINES_PER_PAGE, contentLines.length);
 		String pageContent = String.join("\n", Arrays.copyOfRange(contentLines, startIndex, endIndex));


### PR DESCRIPTION
## 📄 구현 내용 설명
- 같은 문제입니다,, 쿼리로 넣을때는 들여쓰기를 db에서 \r\n으로 인식하는데 swagger로 넣을때는 \n로 넣기때문에 그부분을 고려해서 페이지 분리를 하는것으로 코드를 변경했습니다
