### PR TITLE
페널티 감점 구현

### DIFF
--- a/backend/src/main/java/com/project/Tamago/common/enums/Level.java
+++ b/backend/src/main/java/com/project/Tamago/common/enums/Level.java
@@ -1,0 +1,27 @@
+package com.project.Tamago.common.enums;
+
+import java.util.Arrays;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Level {
+	LEVEL_1(0, 360, 1),
+	LEVEL_2(361, 630, 2),
+	LEVEL_3(631, 810, 3),
+	LEVEL_4(811, 900, 4),
+	LEVEL_5(901, Integer.MAX_VALUE, 5);
+
+	private final int minMmr;
+	private final int maxMmr;
+	private final int level;
+
+	public static Level of(int mmr) {
+		return Arrays.stream(Level.values())
+			.filter(level -> mmr >= level.minMmr && mmr <= level.maxMmr)
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("Invalid MMR: " + mmr));
+	}
+}

--- a/backend/src/main/java/com/project/Tamago/common/enums/ResponseCode.java
+++ b/backend/src/main/java/com/project/Tamago/common/enums/ResponseCode.java
@@ -24,6 +24,7 @@ public enum ResponseCode {
 	USERS_EXISTS_PASSWORD(3005, "유저 비밀번호 값을 확인해주세요."),
 	LONG_TYPING_INFO_NOT_EXISTS(4001, "해당 긴 글이 존재하지 않습니다."),
 	CURRENT_PAGE_NOT_EXISTS(4002, "연습한 페이지가 없습니다"),
+	TIER_NOT_FOUND(5000, "티어 정보를 찾을 수 없습니다"),
 	;
 
 	private final int code;

--- a/backend/src/main/java/com/project/Tamago/controller/TypingExamController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TypingExamController.java
@@ -25,11 +25,11 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/typing")
+@RequestMapping("/typing/exam")
 public class TypingExamController {
 	private final TypingExamService typingExamService;
 
-	@GetMapping("exam/long")
+	@GetMapping("long")
 	public CustomResponse<LongTypingDetailResDto> findLongExam(@RequestParam String language,
 		@Login LoginResolverDto loginResolverDto) {
 		if (Stream.of(Language.values()).noneMatch(element -> element.name().equals(language)))
@@ -37,11 +37,20 @@ public class TypingExamController {
 		return new CustomResponse<>(
 			typingExamService.findLongExam(loginResolverDto.getUserId(), Language.valueOf(language)));
 	}
-	@GetMapping("exam/short")
+	@GetMapping("short")
 	public CustomResponse<ShortTypingListResDto> findShortExam(@RequestParam String language,
 		@Login LoginResolverDto loginResolverDto) {
 		if (Stream.of(Language.values()).noneMatch(element -> element.name().equals(language)))
 			throw new CustomException(ResponseCode.INVALID_PARAMETER);
 		return new CustomResponse<>(typingExamService.findShortExam(loginResolverDto.getUserId(), Language.valueOf(language)));
 	}
+
+	@PostMapping("penalties")
+	public CustomResponse<Void> savePenalties(@RequestParam String language, @Login LoginResolverDto loginResolverDto) {
+		if (Stream.of(Language.values()).noneMatch(element -> element.name().equals(language)))
+			throw new CustomException(ResponseCode.INVALID_PARAMETER);
+		typingExamService.savePenalties(loginResolverDto.getUserId(), Language.valueOf(language));
+		return new CustomResponse<>();
+	}
+
 }

--- a/backend/src/main/java/com/project/Tamago/controller/TypingExamController.java
+++ b/backend/src/main/java/com/project/Tamago/controller/TypingExamController.java
@@ -29,7 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 public class TypingExamController {
 	private final TypingExamService typingExamService;
 
-	@GetMapping("long")
+	@GetMapping("/long")
 	public CustomResponse<LongTypingDetailResDto> findLongExam(@RequestParam String language,
 		@Login LoginResolverDto loginResolverDto) {
 		if (Stream.of(Language.values()).noneMatch(element -> element.name().equals(language)))
@@ -37,7 +37,7 @@ public class TypingExamController {
 		return new CustomResponse<>(
 			typingExamService.findLongExam(loginResolverDto.getUserId(), Language.valueOf(language)));
 	}
-	@GetMapping("short")
+	@GetMapping("/short")
 	public CustomResponse<ShortTypingListResDto> findShortExam(@RequestParam String language,
 		@Login LoginResolverDto loginResolverDto) {
 		if (Stream.of(Language.values()).noneMatch(element -> element.name().equals(language)))
@@ -45,7 +45,7 @@ public class TypingExamController {
 		return new CustomResponse<>(typingExamService.findShortExam(loginResolverDto.getUserId(), Language.valueOf(language)));
 	}
 
-	@PostMapping("penalties")
+	@PostMapping("/penalties")
 	public CustomResponse<Void> savePenalties(@RequestParam String language, @Login LoginResolverDto loginResolverDto) {
 		if (Stream.of(Language.values()).noneMatch(element -> element.name().equals(language)))
 			throw new CustomException(ResponseCode.INVALID_PARAMETER);

--- a/backend/src/main/java/com/project/Tamago/domain/Tier.java
+++ b/backend/src/main/java/com/project/Tamago/domain/Tier.java
@@ -20,6 +20,7 @@ import org.hibernate.annotations.DynamicInsert;
 import org.springframework.security.core.parameters.P;
 
 import com.project.Tamago.common.enums.Language;
+import com.project.Tamago.common.enums.Level;
 import com.project.Tamago.common.enums.Mode;
 
 import lombok.AccessLevel;
@@ -52,14 +53,28 @@ public class Tier extends BaseTimeEntity {
 	@ColumnDefault("0")
 	private Integer mmr;
 
+	@ColumnDefault("0")
+	private Integer beforeMmr;
+
 	@ColumnDefault("false")
 	private Boolean status;
 
-	public void applyPenalty(int penalty) {
+	public void applyPenalty(int penalty, boolean isDirectPenalty) {
+		this.beforeMmr = this.mmr;
 		this.mmr = Math.max(0, this.mmr - penalty);
-		this.status = true;
+		updateLevel();
+		if (isDirectPenalty) {
+			this.status = true;
+		}
 	}
 	public void initStatus() {
 		this.status = false;
+	}
+
+	public void updateLevel() {
+		int newLevel = Level.of(this.mmr).getLevel();
+		if (this.level != newLevel) {
+			this.level = newLevel;
+		}
 	}
 }

--- a/backend/src/main/java/com/project/Tamago/service/TypingExamService.java
+++ b/backend/src/main/java/com/project/Tamago/service/TypingExamService.java
@@ -1,6 +1,7 @@
 package com.project.Tamago.service;
 
 import static com.project.Tamago.common.Constant.*;
+import static com.project.Tamago.common.enums.Mode.*;
 import static com.project.Tamago.common.enums.ResponseCode.*;
 import static com.project.Tamago.common.enums.Score.*;
 
@@ -50,7 +51,13 @@ public class TypingExamService {
 		modifyTier(userId, language);
 		List<ShortTypingDto> shortTypings = TypingUtil.getRandomShortTypings(
 			typingRepository.findByContentTypeIsFalseAndLanguageIs(language.toString()), EXAM_SHORT_TYPING_SIZE);
-		return new ShortTypingListResDto(0, "practice", shortTypings);
+		return new ShortTypingListResDto(0, ACTUAL.toString(), shortTypings);
+	}
+
+	public void savePenalties(Integer userId, Language language) {
+		Tier tier = tierRepository.findByUserIdAndLanguage(userId, language)
+			.orElseThrow(() -> new CustomException(TIER_NOT_FOUND));
+		tier.applyPenalty(PENALTY.getScore(), true);
 	}
 
 	private void modifyTier(Integer userId, Language language) {
@@ -67,7 +74,7 @@ public class TypingExamService {
 			tier.initStatus();
 			return;
 		}
-		tier.applyPenalty(PENALTY.getScore());
+		tier.applyPenalty(PENALTY.getScore(), false);
 	}
 
 	private void createNewTier(Integer userId, Language language) {

--- a/backend/src/test/java/com/project/Tamago/service/TypingExamServiceTest.java
+++ b/backend/src/test/java/com/project/Tamago/service/TypingExamServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -14,6 +15,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 
 import com.project.Tamago.common.enums.Language;
 import com.project.Tamago.domain.LongTyping;
+import com.project.Tamago.domain.Tier;
 import com.project.Tamago.domain.User;
 import com.project.Tamago.dto.responseDto.LongTypingDetailResDto;
 import com.project.Tamago.repository.LongTypingRepository;
@@ -69,4 +71,35 @@ class TypingExamServiceTest {
 		assertNotNull(result);
 		assertEquals(result.getTitle(), longTyping.getTitle());
 	}
+
+	@Test
+	@DisplayName("티어 감점 테스트")
+	@WithMockUser(username = "1", authorities = {"ROLE_USER"})
+	public void savePenaltiesTest() {
+		// given
+
+		User user = User.builder()
+			.id(1)
+			.email("test@naver.com")
+			.nickname("test")
+			.password("1234")
+			.build();
+		Language language = Language.ENGLISH;
+		Tier tier = Tier.builder()
+			.user(user)
+			.language(language)
+			.mmr(1000)
+			.level(5)
+			.build();
+
+		when(tierRepository.findByUserIdAndLanguage(user.getId(), language)).thenReturn(Optional.of(tier));
+
+		// when
+		typingExamService.savePenalties(user.getId(), language);
+
+		// then
+		verify(tierRepository, times(1)).findByUserIdAndLanguage(user.getId(), language);
+		assertEquals(995, tier.getMmr());
+	}
+
 }


### PR DESCRIPTION
## 📄 구현 내용 설명
- 실전모드에서 나가기 버튼을 눌렀을때 페널티 감점을 구현했습니다
### ⛱️ 주요 변경 사항

- 기존 페널티 감점 메소드를 활용했는데 브라우저를 나갔을때 감점하는 방식을 조금더 구체화했습니다
   - 브라우저를 나가서 다음번에 실전모드를 실행시에는 감점을 하는대신 티어의 점수반영을 true로 바꾸지않습니다 true로 바꾸게 되면 다시 브라우저를 나가고 들어왔을때는 감점이 되지않기때문입니다 어차피 실전모드를 완벽히 마치면 true로 바뀌기 때문에 문제없을듯합니다
   - 나가기 버튼을 눌러 감점을 당할때는 점수 반영을 true로 했습니다 
   - 조언해주신대로 티어테이블에 beforeMMR추가했습니다!

### 🙋 이 부분을 리뷰해주세요

- 차감되는 점수에 따라서 updateLevel메소드를 통해서 구간별 점수에 따른 레벨로 초기화해줬습니다
