### PR TITLE
[#288] 긴 글 관련 버그 해결

### DIFF
--- a/client/src/components/typing/long/Exam/index.tsx
+++ b/client/src/components/typing/long/Exam/index.tsx
@@ -208,9 +208,9 @@ export default function ExamLongTyping({
       const prevComponents = userInfos.current[textareaLength - 1].components;
 
       userInfos.current[textareaLength - 1] = {
-        char: textarea[textareaLength - 1],
-        type: getCharType(textarea[textareaLength - 1]),
-        components: disassemble(textarea[textareaLength - 1]),
+        char: value[textareaLength - 1],
+        type: getCharType(value[textareaLength - 1]),
+        components: disassemble(value[textareaLength - 1]),
       };
 
       const currComponents = userInfos.current[textareaLength - 1].components;

--- a/client/src/components/typing/long/Exam/index.tsx
+++ b/client/src/components/typing/long/Exam/index.tsx
@@ -7,7 +7,7 @@ import { useRecoilValue } from 'recoil';
 import { examPenaltiesAPI, getTypingHistoryAPI } from '@/apis/typing';
 import { userProfileState } from '@/atoms/userProfile';
 import Confirm from '@/components/common/Confirm';
-import PracticeResultModal from '@/components/common/ResultModal/practice-mode';
+import ExamResultModal from '@/components/common/ResultModal/exam-mode';
 import LongLayout from '@/components/typing/long/Layout';
 import TypingHeader from '@/components/typing/long/TypingHeader';
 import TypingLine from '@/components/typing/long/TypingLine';
@@ -319,8 +319,7 @@ export default function ExamLongTyping({
         actionLabel='그만하기'
         closeLabel='계속하기'
       />
-      <PracticeResultModal
-        title={`${title} (${currentPage}/${totalPage})`}
+      <ExamResultModal
         isOpen={isResultModalOpen}
         actionLabel='다시하기'
         onAction={onModalButtonClick}
@@ -331,6 +330,7 @@ export default function ExamLongTyping({
           typingWpm: typingWpm.current,
         }}
         endTime={new Date()}
+        mode='long'
       />
     </>
   );

--- a/client/src/components/typing/long/Layout/index.tsx
+++ b/client/src/components/typing/long/Layout/index.tsx
@@ -1,11 +1,4 @@
-import { Box } from '@chakra-ui/react';
-import styled from '@emotion/styled';
-
-const GridBackground = styled.div`
-  width: 100%;
-  background-size: 50px 50px;
-  background-image: linear-gradient(90deg, #fff6f1 1px, transparent 1px), linear-gradient(#fff6f1 1px, transparent 1px);
-`;
+import { Box, Flex } from '@chakra-ui/react';
 
 interface LongLayoutProps {
   children: React.ReactNode;
@@ -14,11 +7,20 @@ interface LongLayoutProps {
 export default function LongLayout({ children }: LongLayoutProps) {
   return (
     <>
-      <GridBackground>
+      <Flex
+        as='main'
+        flexDirection='column'
+        minW='1100px'
+        w='100%'
+        backgroundColor='background.main'
+        backgroundImage='linear-gradient(#EFDFD3 .0375rem, transparent .0625rem), linear-gradient(to right, #EFDFD3 .0625rem, #FFF .0625rem);'
+        backgroundSize='3.75rem 3.7656rem'
+        pos='relative'
+      >
         <Box w='1170px' p='35px 0' m='auto' minW='1100px'>
           {children}
         </Box>
-      </GridBackground>
+      </Flex>
     </>
   );
 }

--- a/client/src/components/typing/long/Practice/index.tsx
+++ b/client/src/components/typing/long/Practice/index.tsx
@@ -156,9 +156,9 @@ export default function PracticeLongTyping({
       const prevComponents = userInfos.current[textareaLength - 1].components;
 
       userInfos.current[textareaLength - 1] = {
-        char: textarea[textareaLength - 1],
-        type: getCharType(textarea[textareaLength - 1]),
-        components: disassemble(textarea[textareaLength - 1]),
+        char: value[textareaLength - 1],
+        type: getCharType(value[textareaLength - 1]),
+        components: disassemble(value[textareaLength - 1]),
       };
 
       const currComponents = userInfos.current[textareaLength - 1].components;

--- a/client/src/pages/actual/long/index.tsx
+++ b/client/src/pages/actual/long/index.tsx
@@ -5,6 +5,8 @@ import { examLongTypingAPI } from '@/apis/typing';
 import Footer from '@/components/footer';
 import Header from '@/components/header';
 import ExamLongTyping from '@/components/typing/long/Exam';
+import { LOGIN_PATH, MAIN_PATH } from '@/constants/paths';
+import type { ApiErrorResponse } from '@/types/apiResponse';
 import type { LongTypingDetail } from '@/types/typing';
 
 export default function ExamLongTypingPage() {
@@ -13,8 +15,16 @@ export default function ExamLongTypingPage() {
   const [data, setData] = useState<LongTypingDetail | null>(null);
 
   const getLongTyping = async (language: string) => {
-    const { result } = await examLongTypingAPI(language);
-    setData(result);
+    try {
+      const { result } = await examLongTypingAPI(language);
+      setData(result);
+    } catch (error) {
+      const customError = error as ApiErrorResponse;
+      if (customError.code === 400) {
+        router.replace(LOGIN_PATH);
+      }
+      router.replace(MAIN_PATH);
+    }
   };
 
   useEffect(() => {

--- a/client/src/utils/typing.ts
+++ b/client/src/utils/typing.ts
@@ -42,6 +42,8 @@ export const getTypingSpeed = ({
 };
 
 export const getWrongKeys = (contentInfos: CharInfo[], typingInfos: CharInfo[]) => {
+  console.log(JSON.stringify(contentInfos, null, 2), JSON.stringify(typingInfos, null, 2));
+
   const wrongKeys: Record<string, { total: number; count: number }> = {};
   contentInfos.forEach((contentInfo, i) => {
     const { components: contentComponents } = contentInfo;
@@ -58,12 +60,6 @@ export const getWrongKeys = (contentInfos: CharInfo[], typingInfos: CharInfo[]) 
       }
     });
   });
-
-  for (const key in wrongKeys) {
-    if (wrongKeys[key].count === 0) {
-      delete wrongKeys[key];
-    }
-  }
 
   return wrongKeys;
 };

--- a/client/src/utils/typing.ts
+++ b/client/src/utils/typing.ts
@@ -42,8 +42,6 @@ export const getTypingSpeed = ({
 };
 
 export const getWrongKeys = (contentInfos: CharInfo[], typingInfos: CharInfo[]) => {
-  console.log(JSON.stringify(contentInfos, null, 2), JSON.stringify(typingInfos, null, 2));
-
   const wrongKeys: Record<string, { total: number; count: number }> = {};
   contentInfos.forEach((contentInfo, i) => {
     const { components: contentComponents } = contentInfo;


### PR DESCRIPTION
## 📄 구현 내용 설명
- close #288 
- 긴 글 리스트 배경 다른 페이지와 통일
- 긴 글 틀린 글자 구하는 로직 수정
- 긴 글 실전 모드에서 토큰이 만료될 경우 로그인 페이지로 이동

### ⛱️ 주요 변경 사항

- 리스트 배경은 선택 페이지의 배경으로 가져다 썼습니다.
- 긴 글 틀린 글자가 잘못 보내고 있어 수정했습니다.
- 긴 글 실전 모드에서 토큰이 만료될 경우 즉 긴 글 실전 타이핑 api의 응답에 대해 예외처리하였습니다.

### 🙋 이 부분을 리뷰해주세요

-
-

### 🤔 여기를 참고하면 도움이 돼요

-   [링크 이름](링크 주소)
-
