### PR TITLE
tab 키 입력시 indent

### DIFF
--- a/client/src/components/common/Checkbox/index.stories.tsx
+++ b/client/src/components/common/Checkbox/index.stories.tsx
@@ -21,5 +21,5 @@ const Template: ComponentStory<typeof CustomCheckbox> = (args) => {
 export const Checkbox: ComponentStory<typeof CustomCheckbox> = Template.bind({});
 
 Checkbox.args = {
-  labelText: '테스트 텍스트입니다',
+  labeltext: '테스트 텍스트입니다',
 };

--- a/client/src/components/common/Checkbox/index.tsx
+++ b/client/src/components/common/Checkbox/index.tsx
@@ -17,18 +17,18 @@ const CheckedIcon = () => {
 };
 
 interface CheckboxProps {
-  labelText?: string;
+  labeltext?: string;
 }
 
 export const CustomCheckbox = (props: UseCheckboxProps & CheckboxProps) => {
-  const { labelText } = props;
+  const { labeltext } = props;
   const { state, getCheckboxProps, getInputProps, getLabelProps, htmlProps } = useCheckbox(props);
   return (
     <FormLabel
       display='flex'
       alignItems='center'
       borderColor='gray.main'
-      gap={labelText ? '14px' : '0'}
+      gap={labeltext ? '14px' : '0'}
       cursor='pointer'
       m={0}
       {...htmlProps}
@@ -50,7 +50,7 @@ export const CustomCheckbox = (props: UseCheckboxProps & CheckboxProps) => {
         {state.isChecked && <CheckedIcon />}
       </Flex>
       <Text size='15px' {...getLabelProps()}>
-        {labelText}
+        {labeltext}
       </Text>
     </FormLabel>
   );

--- a/client/src/components/home/Banner/index.tsx
+++ b/client/src/components/home/Banner/index.tsx
@@ -4,7 +4,7 @@ export default function Banner() {
   return (
     <Flex w='100%' h='199px' bgColor='primary.main'>
       <Container maxW='container.xl' h='100%' display='flex' alignItems='center' justifyContent='space-between'>
-        <Text fontSize='1.875rem' fontWeight='700' color='white.light' marginLeft='2.0625rem'>
+        <Text fontSize='1.875rem' fontWeight='700' color='white.light' ml='.5rem'>
           이제는 개발에 재미를 더해요.
         </Text>
 

--- a/client/src/components/home/Menus/index.tsx
+++ b/client/src/components/home/Menus/index.tsx
@@ -18,23 +18,23 @@ export default function Menus() {
   return (
     <Container
       maxW='container.xl'
-      h='80vh'
+      h='50.5625rem'
       py='6.9375rem'
       ref={observerRef}
       opacity={animationTrigger ? 1 : 0}
       animation={animationTrigger ? `${fadeIn} 1s linear` : ''}
     >
-      <Text fontSize='1.5625rem' marginBottom='.9375rem' marginLeft='1.375rem'>
+      <Text fontSize='1.5625rem' marginBottom='.9375rem' ml='.5rem'>
         About Tamago
       </Text>
-      <Text fontSize='2.25rem' fontWeight='bold'>
+      <Text fontSize='2.25rem' fontWeight='bold' ml='.5rem'>
         개발할 때 쓰이는 코드로
         <br />
         다양하게 타자 연습을
         <br />할 수 있어요.
       </Text>
 
-      <Flex marginTop='4.6875rem' w='100%' justifyContent='space-around'>
+      <Flex marginTop='4.6875rem' w='100%' justifyContent='space-between' ml='.5rem'>
         <Link href={PRACTICE_LONG_PATH_LIST}>
           <MenuCard language='kr' title='긴 글 연습' content='Lorem ipsum dolor sit amet, consectetu' />
         </Link>

--- a/client/src/components/home/Stats/index.tsx
+++ b/client/src/components/home/Stats/index.tsx
@@ -60,7 +60,7 @@ export default function Stats() {
       opacity={animationTrigger ? 1 : 0}
       animation={animationTrigger ? `${fadeIn} 1s linear` : ''}
     >
-      <Container maxW='container.xl' py='6.9375rem' display='flex' gap='1.1875rem' justifyContent='space-evenly'>
+      <Container maxW='container.xl' py='6.9375rem' display='flex' gap='1.1875rem' justifyContent='space-between'>
         <Flex>
           <Flex
             w='48.25rem'

--- a/client/src/components/login/Form/index.tsx
+++ b/client/src/components/login/Form/index.tsx
@@ -64,7 +64,7 @@ function LoginForm({ onLogin }: LoginFormProps) {
       </Box>
 
       <Flex w='full' justifyContent='space-between' mt='20px'>
-        <CustomCheckbox labelText='아이디 저장' />
+        <CustomCheckbox labeltext='아이디 저장' />
         <Flex gap='13px' fontSize='15px'>
           <Link href={INQUIRY_PW_PATH}>
             <Text color='gray.dark'>비밀번호 찾기</Text>

--- a/client/src/components/signup/Terms/index.tsx
+++ b/client/src/components/signup/Terms/index.tsx
@@ -33,18 +33,18 @@ export default function SignupTerms() {
 
   return (
     <Flex direction='column' w='full' gap='16px'>
-      <CustomCheckbox name='all' labelText='모두 동의합니다.' isChecked={allChecked} onChange={handleCheckboxChange} />
+      <CustomCheckbox name='all' labeltext='모두 동의합니다.' isChecked={allChecked} onChange={handleCheckboxChange} />
       <Divider borderColor='gray.main' />
       <CustomCheckbox
         name='age'
-        labelText='[필수] 만 14세 이상입니다.'
+        labeltext='[필수] 만 14세 이상입니다.'
         isChecked={age}
         onChange={handleCheckboxChange}
       />
       <Flex alignItems='center' justify='space-between'>
         <CustomCheckbox
           name='service'
-          labelText='[필수] 서비스 이용약관 동의'
+          labeltext='[필수] 서비스 이용약관 동의'
           isChecked={service}
           onChange={handleCheckboxChange}
         />
@@ -53,7 +53,7 @@ export default function SignupTerms() {
       <Flex alignItems='center' justify='space-between'>
         <CustomCheckbox
           name='privacy'
-          labelText='[필수] 서비스 이용약관 동의'
+          labeltext='[필수] 서비스 이용약관 동의'
           isChecked={privacy}
           onChange={handleCheckboxChange}
         />
@@ -62,7 +62,7 @@ export default function SignupTerms() {
       <Flex alignItems='center' justify='space-between'>
         <CustomCheckbox
           name='marketing'
-          labelText='[필수] 서비스 이용약관 동의'
+          labeltext='[필수] 서비스 이용약관 동의'
           isChecked={marketing}
           onChange={handleCheckboxChange}
         />

--- a/client/src/components/typing/long/List/index.tsx
+++ b/client/src/components/typing/long/List/index.tsx
@@ -81,7 +81,7 @@ export default function PracticeLongList({ currentPage, totalPage, typingList }:
                       href={`${PRACTICE_LONG_PATH_DETAIL}?typingId=${typingId}&pageNum=1&isTyping=true`}
                       onMouseOver={() => {
                         // todo: 긴 글 제목에 마우스 호버시 썸네일 표시
-                        console.log(thumbnail);
+                        // console.log(thumbnail);
                       }}
                     >
                       {title}

--- a/client/src/components/typing/long/Practice/index.tsx
+++ b/client/src/components/typing/long/Practice/index.tsx
@@ -1,6 +1,7 @@
 import { Flex, Textarea } from '@chakra-ui/react';
 import { disassemble } from 'hangul-js';
 import { useRouter } from 'next/router';
+import type { KeyboardEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 
@@ -211,6 +212,14 @@ export default function PracticeLongTyping({
     }
   };
 
+  const insertTab = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      typingStates.current = typingStates.current.slice(0, -1) + '  ' + TYPING_STATE.FOCUS;
+      setTextarea((prev) => prev + '  ');
+    }
+  };
+
   const handleExit = () => {
     router.push(PRACTICE_LONG_PATH_LIST);
   };
@@ -247,6 +256,7 @@ export default function PracticeLongTyping({
             onCopy={(e) => e.preventDefault()}
             onCut={(e) => e.preventDefault()}
             onPaste={(e) => e.preventDefault()}
+            onKeyDown={insertTab}
           />
           {slicedContentAndStrings(content, textarea, typingStates.current).map(
             ([originalLine, userLine, states], i) => (


### PR DESCRIPTION
## 📄 구현 내용 설명
긴 글 연습에서 tab키를 통해 indent를 할 수 있습니다.
아래 글에서 두 번째 줄에서 tab을 통해, indent로 사용하는 모습입니다.

![indent](https://user-images.githubusercontent.com/59170680/233780430-e511e63c-a27c-48ff-8c03-3b07bd871c16.gif)

### ⛱️ 주요 변경 사항

- 긴 글 연습에서 tab을 입력하면 indent로 사용 가능합니다. 
- `customCheckbox` 컴포넌트에서 labeltext props에서 발생하던 키 오류를 해결했습니다.
- 수민님의 피드백에 따라 메인화면 레이아웃을 정비했습니다.