### PR TITLE
[#306] 긴 글 타이핑 마우스 호버 시 썸네일 노출

### DIFF
--- a/client/src/components/typing/long/List/TypingThumbnail/index.tsx
+++ b/client/src/components/typing/long/List/TypingThumbnail/index.tsx
@@ -1,0 +1,24 @@
+import { Box } from '@chakra-ui/react';
+
+interface TypingThumbnailProps {
+  thumbnail: string;
+  y: number;
+  x: number;
+}
+
+export default function TypingThumbnail({ thumbnail, y, x }: TypingThumbnailProps) {
+  return (
+    <Box
+      p={'10px'}
+      border={'0.6px solid black'}
+      borderRadius={'10px'}
+      backgroundColor={'white'}
+      pos={'absolute'}
+      left={x + 10}
+      top={y + 10}
+      zIndex={100}
+    >
+      {thumbnail}
+    </Box>
+  );
+}

--- a/client/src/components/typing/long/List/TypingThumbnail/index.tsx
+++ b/client/src/components/typing/long/List/TypingThumbnail/index.tsx
@@ -15,7 +15,7 @@ export default function TypingThumbnail({ thumbnail, y, x }: TypingThumbnailProp
       backgroundColor={'white'}
       pos={'absolute'}
       left={x + 10}
-      top={y + 10}
+      top={`${y - 78}px`}
       zIndex={100}
     >
       {thumbnail}

--- a/client/src/components/typing/long/List/index.tsx
+++ b/client/src/components/typing/long/List/index.tsx
@@ -14,6 +14,7 @@ import {
   Tr,
 } from '@chakra-ui/react';
 import Link from 'next/link';
+import { useRef, useState } from 'react';
 
 import PracticeLongLayout from '@/components/typing/long/Layout';
 import { LONG_TYPING_TYPE } from '@/constants/language';
@@ -24,6 +25,7 @@ import { Search } from '@/icons/Search';
 import type { LongTypingItem } from '@/types/typing';
 
 import TypingListPagination from './TypingListPagination';
+import TypingThumbnail from './TypingThumbnail';
 
 interface PracticeLongListProps {
   currentPage: number;
@@ -32,6 +34,28 @@ interface PracticeLongListProps {
 }
 
 export default function PracticeLongList({ currentPage, totalPage, typingList }: PracticeLongListProps) {
+  const [currThumbnail, setCurrThumbnail] = useState<{ thumbnail: string; y: number; x: number }>();
+
+  const timeout = useRef(0);
+
+  const onMouseMove = (thumbnail: string) => {
+    return (e: React.MouseEvent<HTMLDivElement>) => {
+      clearTimeout(timeout.current);
+      if (thumbnail == currThumbnail?.thumbnail) {
+        setCurrThumbnail({ ...currThumbnail, y: e.pageY, x: e.pageX });
+        return;
+      }
+      timeout.current = window.setTimeout(() => {
+        setCurrThumbnail({ thumbnail, y: e.pageY, x: e.pageX });
+      }, 1000);
+    };
+  };
+
+  const onMouseLeave = () => {
+    clearTimeout(timeout.current);
+    setCurrThumbnail(undefined);
+  };
+
   return (
     <PracticeLongLayout>
       <Flex direction='column'>
@@ -76,14 +100,13 @@ export default function PracticeLongList({ currentPage, totalPage, typingList }:
               {typingList.map(({ language, thumbnail, title, totalPage, typingId, viewCount }: LongTypingItem) => (
                 <Tr key={typingId}>
                   <Td textAlign='center'>{typingId}</Td>
-                  <Td>
-                    <Link
-                      href={`${PRACTICE_LONG_PATH_DETAIL}?typingId=${typingId}&pageNum=1&isTyping=true`}
-                      onMouseOver={() => {
-                        // todo: 긴 글 제목에 마우스 호버시 썸네일 표시
-                        // console.log(thumbnail);
-                      }}
-                    >
+                  <Td
+                    pos='relative'
+                    overflow={'visible'}
+                    onMouseMove={onMouseMove(thumbnail)}
+                    onMouseLeave={onMouseLeave}
+                  >
+                    <Link href={`${PRACTICE_LONG_PATH_DETAIL}?typingId=${typingId}&pageNum=1&isTyping=true`}>
                       {title}
                     </Link>
                   </Td>
@@ -105,6 +128,7 @@ export default function PracticeLongList({ currentPage, totalPage, typingList }:
         </TableContainer>
         <TypingListPagination currentPage={currentPage} totalPage={totalPage} />
       </Flex>
+      {currThumbnail && <TypingThumbnail thumbnail={currThumbnail.thumbnail} y={currThumbnail.y} x={currThumbnail.x} />}
     </PracticeLongLayout>
   );
 }


### PR DESCRIPTION
## 📄 구현 내용 설명

- 타이핑 제목 쉘을 1초 이상 호버하고 있을 경우 썸네일 노출
- close #306 

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/65846992/233851223-6d9d4385-573c-4ba1-b531-da69941e2bbd.gif)


### ⛱️ 주요 변경 사항

- 
-

### 🙋 이 부분을 리뷰해주세요

- 
-

### 🤔 여기를 참고하면 도움이 돼요

-   [링크 이름](링크 주소)
-
