### PR TITLE
[#325] 긴 글 목록 페이지 정렬 기능 추가

### DIFF
--- a/client/src/apis/typing.ts
+++ b/client/src/apis/typing.ts
@@ -67,8 +67,14 @@ export const getExamShortTypingWritingsAPI = async (
   return res.data;
 };
 
-export const getLongTypingListAPI = async (page: number): Promise<LongTypingListResultType> => {
-  const res = await requestWithoutAuth.get(`/typing/long?page=${page}`);
+export const getLongTypingListAPI = async ({
+  page,
+  sortBy,
+}: {
+  page: number;
+  sortBy?: string;
+}): Promise<LongTypingListResultType> => {
+  const res = await requestWithoutAuth.get(`/typing/long?page=${page}${sortBy ? '&sortBy=' + sortBy : ''}`);
 
   return res.data;
 };

--- a/client/src/apis/typing.ts
+++ b/client/src/apis/typing.ts
@@ -2,6 +2,7 @@ import { requestWithAuth, requestWithoutAuth } from '@/apis';
 import type { ErrorResponse } from '@/apis/error';
 import type { ApiResponse } from '@/types/apiResponse';
 import type { LanguageType } from '@/types/language';
+import type { SortBy } from '@/types/longTyping';
 import type { LongTypingDetail, LongTypingItem } from '@/types/typing';
 import type { TypingMode } from '@/types/typing';
 
@@ -72,7 +73,7 @@ export const getLongTypingListAPI = async ({
   sortBy,
 }: {
   page: number;
-  sortBy?: string;
+  sortBy?: SortBy;
 }): Promise<LongTypingListResultType> => {
   const res = await requestWithoutAuth.get(`/typing/long?page=${page}${sortBy ? '&sortBy=' + sortBy : ''}`);
 

--- a/client/src/components/typing/long/List/SortBy/index.tsx
+++ b/client/src/components/typing/long/List/SortBy/index.tsx
@@ -1,4 +1,4 @@
-import { Flex, Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react';
+import { Flex, Menu, MenuButton, MenuDivider, MenuItem, MenuList } from '@chakra-ui/react';
 import Link from 'next/link';
 
 import { PRACTICE_LONG_PATH_LIST } from '@/constants/paths';
@@ -22,17 +22,36 @@ const sortByItems = [
 export default function SortBy() {
   return (
     <Menu>
-      <MenuButton w={'96px'} h={'34px'} border={'0.6px solid #101010'} borderRadius={16} bg={'#fafafa'}>
+      <MenuButton
+        fontWeight={'500'}
+        w={'96px'}
+        h={'34px'}
+        border={'0.6px solid #101010'}
+        borderRadius={16}
+        bg={'background.white'}
+      >
         <Flex alignItems={'center'} justify={'center'} gap={'15px'}>
-          <b>정렬</b>
+          정렬
           <UpDownArrow />
         </Flex>
       </MenuButton>
-      <MenuList>
-        {sortByItems.map((item, index) => (
-          <Link key={index} href={item.path}>
-            <MenuItem>{item.label}</MenuItem>
-          </Link>
+      <MenuList p={0} minW={0} w={'96px'} border={'0.6px solid #101010'} borderRadius={16} bg={'background.white'}>
+        {sortByItems.map((item, index, items) => (
+          <>
+            <Link key={index} href={item.path}>
+              <MenuItem
+                _hover={{ color: 'primary.dark' }}
+                fontWeight={'500'}
+                w={'fit-content'}
+                bg={'background.white'}
+                p={0}
+                m={'15px 18px'}
+              >
+                {item.label}
+              </MenuItem>
+            </Link>
+            {index !== items.length - 1 && <MenuDivider />}
+          </>
         ))}
       </MenuList>
     </Menu>

--- a/client/src/components/typing/long/List/SortBy/index.tsx
+++ b/client/src/components/typing/long/List/SortBy/index.tsx
@@ -1,0 +1,40 @@
+import { Flex, Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react';
+import Link from 'next/link';
+
+import { PRACTICE_LONG_PATH_LIST } from '@/constants/paths';
+import UpDownArrow from '@/icons/UpDownArrow';
+
+const sortByItems = [
+  {
+    label: '최신순',
+    path: `${PRACTICE_LONG_PATH_LIST}?page=1&sortBy=latest`,
+  },
+  {
+    label: '조회수순',
+    path: `${PRACTICE_LONG_PATH_LIST}?page=1&sortBy=viewCount`,
+  },
+  {
+    label: '오래된순',
+    path: `${PRACTICE_LONG_PATH_LIST}?page=1&sortBy=oldest`,
+  },
+];
+
+export default function SortBy() {
+  return (
+    <Menu>
+      <MenuButton w={'96px'} h={'34px'} border={'0.6px solid #101010'} borderRadius={16} bg={'#fafafa'}>
+        <Flex alignItems={'center'} justify={'center'} gap={'15px'}>
+          <b>정렬</b>
+          <UpDownArrow />
+        </Flex>
+      </MenuButton>
+      <MenuList>
+        {sortByItems.map((item, index) => (
+          <Link key={index} href={item.path}>
+            <MenuItem>{item.label}</MenuItem>
+          </Link>
+        ))}
+      </MenuList>
+    </Menu>
+  );
+}

--- a/client/src/components/typing/long/List/index.tsx
+++ b/client/src/components/typing/long/List/index.tsx
@@ -24,6 +24,7 @@ import { BookmarkOff } from '@/icons/Heart';
 import { Search } from '@/icons/Search';
 import type { LongTypingItem } from '@/types/typing';
 
+import SortBy from './SortBy';
 import TypingListPagination from './TypingListPagination';
 import TypingThumbnail from './TypingThumbnail';
 
@@ -89,11 +90,13 @@ export default function PracticeLongList({ currentPage, totalPage, typingList }:
                 <Th textAlign='center' width='9%'>
                   번호
                 </Th>
-                <Th width='50%'>제목명</Th>
-                <Th width='9%'>타입</Th>
-                <Th width='9%'>페이지 수</Th>
-                <Th width='9%'>조회수</Th>
-                <Th width='14%'></Th>
+                <Th width='42%'>제목명</Th>
+                <Th width='12%'>타입</Th>
+                <Th width='12%'>페이지 수</Th>
+                <Th width='12%'>조회수</Th>
+                <Th width='12%'>
+                  <SortBy />
+                </Th>
               </Tr>
             </Thead>
             <Tbody>

--- a/client/src/constants/language.ts
+++ b/client/src/constants/language.ts
@@ -9,19 +9,19 @@ import type {
 } from '@/types/language';
 import { getRandomProgrammingLanguage } from '@/utils/language';
 
-export const NATION_LANGUAGE: Record<NationLanguageType, NationLanguageType> = {
+export const NATION_LANGUAGE: Record<string, NationLanguageType> = {
   KOREAN: 'KOREAN',
   ENGLISH: 'ENGLISH',
 };
 
-export const PROGRAMMING_LANGUAGE: Record<ProgrammingLanguageType, ProgrammingLanguageType> = {
+export const PROGRAMMING_LANGUAGE: Record<string, ProgrammingLanguageType> = {
   JAVASCRIPT: 'JAVASCRIPT',
   PYTHON: 'PYTHON',
   JAVA: 'JAVA',
   C: 'C',
 };
 
-export const LONG_TYPING_TYPE: Record<LanguageType, string> = {
+export const LONG_TYPING_TYPE: Record<string, string> = {
   KOREAN: '한글',
   ENGLISH: '영어',
   JAVA: 'Java',
@@ -29,7 +29,6 @@ export const LONG_TYPING_TYPE: Record<LanguageType, string> = {
   JAVASCRIPT: 'JavaScript',
   C: 'C',
 };
-
 export const SELECT_LANGUAGE_VALUE: Record<string, SelectLanguageType> = {
   KOREAN: 'KOREAN',
   ENGLISH: 'ENGLISH',

--- a/client/src/constants/language.ts
+++ b/client/src/constants/language.ts
@@ -9,19 +9,19 @@ import type {
 } from '@/types/language';
 import { getRandomProgrammingLanguage } from '@/utils/language';
 
-export const NATION_LANGUAGE: Record<string, NationLanguageType> = {
+export const NATION_LANGUAGE: Record<NationLanguageType, NationLanguageType> = {
   KOREAN: 'KOREAN',
   ENGLISH: 'ENGLISH',
 };
 
-export const PROGRAMMING_LANGUAGE: Record<string, ProgrammingLanguageType> = {
+export const PROGRAMMING_LANGUAGE: Record<ProgrammingLanguageType, ProgrammingLanguageType> = {
   JAVASCRIPT: 'JAVASCRIPT',
   PYTHON: 'PYTHON',
   JAVA: 'JAVA',
   C: 'C',
 };
 
-export const LONG_TYPING_TYPE: Record<string, string> = {
+export const LONG_TYPING_TYPE: Record<LanguageType, string> = {
   KOREAN: '한글',
   ENGLISH: '영어',
   JAVA: 'Java',
@@ -29,6 +29,7 @@ export const LONG_TYPING_TYPE: Record<string, string> = {
   JAVASCRIPT: 'JavaScript',
   C: 'C',
 };
+
 export const SELECT_LANGUAGE_VALUE: Record<string, SelectLanguageType> = {
   KOREAN: 'KOREAN',
   ENGLISH: 'ENGLISH',

--- a/client/src/constants/typing.ts
+++ b/client/src/constants/typing.ts
@@ -16,16 +16,6 @@ export const ACTUAL_TYPING_TIME_LIMIT = {
   SHORT: 5 * 60 * 1000,
 };
 
-// Language Type으로 옮기는게 어떨까요?!
-export const TYPING_TYPE: Record<string, string> = {
-  KOREAN: '한글',
-  ENGLISH: '영어',
-  JAVA: 'Java',
-  PYTHON: 'Python',
-  C: 'C',
-  JAVASCRIPT: 'JavaScript',
-};
-
 export enum TYPING_STATE {
   'DEFAULT' = 'd',
   'CORRECT' = 'c',

--- a/client/src/icons/UpDownArrow.tsx
+++ b/client/src/icons/UpDownArrow.tsx
@@ -1,13 +1,15 @@
+import { Icon } from '@chakra-ui/react';
+
 export default function UpDownArrow() {
   return (
-    <svg width='7' height='12' viewBox='0 0 7 12' fill='none' xmlns='http://www.w3.org/2000/svg'>
+    <Icon width='9px' height='12px' viewBox='0 0 9 12' fill='none' xmlns='http://www.w3.org/2000/svg'>
       <path
-        d='M6 8.5L3.5 11L1 8.5M1 3.5L3.5 1L6 3.5'
+        d='M8 8.5L4.5 11L1 8.5M1 3.5L4.5 1L8 3.5'
         stroke='black'
         strokeWidth='1.2'
         strokeLinecap='round'
         strokeLinejoin='round'
       />
-    </svg>
+    </Icon>
   );
 }

--- a/client/src/pages/practice/long/index.tsx
+++ b/client/src/pages/practice/long/index.tsx
@@ -5,6 +5,7 @@ import { getLongTypingListAPI } from '@/apis/typing';
 import Footer from '@/components/footer';
 import Header from '@/components/header';
 import PracticeLongList from '@/components/typing/long/List';
+import type { SortBy } from '@/types/longTyping';
 import type { LongTypingItem } from '@/types/typing';
 
 export default function PracticeLongPage() {
@@ -14,8 +15,15 @@ export default function PracticeLongPage() {
     null,
   );
 
-  const getLongTypingList = async ({ page, sortBy }: { page: number; sortBy?: string }) => {
-    const { result } = await getLongTypingListAPI({ page, sortBy });
+  const getLongTypingList = async ({ page, sortBy }: { page: number; sortBy?: SortBy }) => {
+    let result;
+
+    try {
+      result = (await getLongTypingListAPI({ page, sortBy })).result;
+    } catch {
+      // 잘못된 정렬기준일 경우
+      result = (await getLongTypingListAPI({ page })).result;
+    }
 
     const { totalPage, longTypings } = result as { totalPage: number; longTypings: LongTypingItem[] };
 
@@ -26,7 +34,7 @@ export default function PracticeLongPage() {
     if (!router.isReady) {
       return;
     }
-    const { page, sortBy } = router.query as { page: string; sortBy?: string };
+    const { page, sortBy } = router.query as { page: string; sortBy?: SortBy };
 
     const pageNumber = isNaN(Number(page)) ? 1 : Number(page);
     getLongTypingList({ page: pageNumber, sortBy });

--- a/client/src/pages/practice/long/index.tsx
+++ b/client/src/pages/practice/long/index.tsx
@@ -14,8 +14,8 @@ export default function PracticeLongPage() {
     null,
   );
 
-  const getLongTypingList = async (page: number) => {
-    const { result } = await getLongTypingListAPI(page);
+  const getLongTypingList = async ({ page, sortBy }: { page: number; sortBy?: string }) => {
+    const { result } = await getLongTypingListAPI({ page, sortBy });
 
     const { totalPage, longTypings } = result as { totalPage: number; longTypings: LongTypingItem[] };
 
@@ -26,9 +26,10 @@ export default function PracticeLongPage() {
     if (!router.isReady) {
       return;
     }
-    const { page } = router.query as { page: string };
+    const { page, sortBy } = router.query as { page: string; sortBy?: string };
 
-    getLongTypingList(Number.isNaN(Number(page)) ? 1 : Number(page));
+    const pageNumber = isNaN(Number(page)) ? 1 : Number(page);
+    getLongTypingList({ page: pageNumber, sortBy });
   }, [router.isReady, router.asPath]);
 
   if (!router.isReady || !data) {

--- a/client/src/types/longTyping.ts
+++ b/client/src/types/longTyping.ts
@@ -1,0 +1,1 @@
+export type SortBy = 'latest' | 'oldest' | 'viewcount';


### PR DESCRIPTION
## 📄 구현 내용 설명
<img width="1379" alt="image" src="https://user-images.githubusercontent.com/65846992/236676533-0b674d2a-01f9-4478-9752-312700030a8a.png">


### ⛱️ 주요 변경 사항
- 
-

### 🙋 이 부분을 리뷰해주세요
- chakra의 menu를 사용해서 select 구현했는데 다른 좋은 방법있으면 알려주시면 감사하겠습니다!
- chakra의 menu를 커스텀하기 까다로워 스타일 관련 코드가 지저분합니다...

### 🤔 여기를 참고하면 도움이 돼요

- [chakra menu](https://chakra-ui.com/docs/components/menu)
- [chakra menu 너비 강제로 바꾸는 법](https://github.com/chakra-ui/chakra-ui/discussions/3640#discussioncomment-959089)
- [chakra menudivider 색상 변경](https://stackoverflow.com/questions/72825693/chakra-ui-how-can-i-change-the-color-of-divider)